### PR TITLE
module: mkDefault PrivateTmp to true 

### DIFF
--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -36,7 +36,7 @@ let
       };
 
       serviceConfig = {
-        PrivateTmp = true;
+        PrivateTmp = lib.mkDefault true;
         ExecStart = "${pkgs.vault}/bin/vault agent -log-level=trace -config ${agentCfgFile}";
         ExecStartPost = waitFor serviceName (agentConfig.environmentFiles ++ agentConfig.secretFiles);
       }
@@ -55,7 +55,7 @@ let
         JoinsNamespaceOf = sidecarServiceName;
       };
       serviceConfig = {
-        PrivateTmp = true;
+        PrivateTmp = lib.mkDefault true;
         EnvironmentFile = agentConfig.environmentFiles;
       };
     };


### PR DESCRIPTION
This is so that we can avoid the "conflicting values set"
module-system-wide assertion and instead allow our nicer assertion to
fire, notifying the user that a certain service is setting PrivateTmp to
false, which won't work with this module.