### PR TITLE
Fix EnvFile handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
         run: nix-instantiate --strict --eval --json ./default.nix -A checks.definition
       - name: Evaluation cases of the helpers
         run: nix-instantiate --strict --eval --json ./default.nix -A checks.helpers
-      # TODO: test the implementation tests once we figure out why basicEnvironment doesn't exit
+      # NOTE: we can't add the implementation tests to CI because of the lack of KVM:
+      #   error: a 'x86_64-linux' with features {kvm, nixos-test} is required to build '/nix/store/5cy5k2lgcfc9apjf3icj74l53bxxf8b0-vm-test-run-unnamed.drv', but I am a 'x86_64-linux' with features {benchmark, big-parallel, nixos-test}
 
   EditorConfig:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -41,21 +41,10 @@ This temporary filessytem will be shared with the target service via the `JoinsN
         # cannot be reloaded.
         changeAction = "restart";
 
-        # The octal mode of /run/keys/environment/EnvFile.
-        # Defaults to 0400.
-        # NOTE: The owner and group of the file are set based on the
-        # infected service's User= and Group= systemd directives.
-        perms = "0400";
-
         templateFiles = {
             # An EnvironmentFile is created for each section here.
             "file-section" = {
                 file = ./example.ctmpl;
-                # The octal mode of /run/keys/environment/file-section.EnvFile.
-                # Defaults to 0400.
-                # NOTE: The owner and group of the file are set based on the
-                # infected service's User= and Group= systemd directives.
-                perms = "0400";
             };
         };
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ This temporary filessytem will be shared with the target service via the `JoinsN
             # Defaults to the secretFiles.defaultChangeAction, and any of those values are valid here too.
             changeAction = "reload";
 
-            # The octal mode of the created secret file (as a string).
+            # The octal mode of the created secret file (as a string). The
+            # leading 0 is optional and implied of not present.
             # Defaults to 0400.
             # NOTE: The owner and group of the file are set based on the
             # infected service's User= and Group= systemd directives.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,21 @@ This temporary filessytem will be shared with the target service via the `JoinsN
         # cannot be reloaded.
         changeAction = "restart";
 
+        # The octal mode of /run/keys/environment/EnvFile.
+        # Defaults to 0400.
+        # NOTE: The owner and group of the file are set based on the
+        # infected service's User= and Group= systemd directives.
+        perms = "0400";
 
         templateFiles = {
             # An EnvironmentFile is created for each section here.
             "file-section" = {
                 file = ./example.ctmpl;
+                # The octal mode of /run/keys/environment/file-section.EnvFile.
+                # Defaults to 0400.
+                # NOTE: The owner and group of the file are set based on the
+                # infected service's User= and Group= systemd directives.
+                perms = "0400";
             };
         };
 

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -45,6 +45,8 @@ let
         };
 
         perms = mkOption {
+          readOnly = true;
+          internal = true;
           description = "The octal mode of the environment file.";
           type = types.str;
           default = "0400";
@@ -83,6 +85,8 @@ let
       };
 
       perms = mkOption {
+        readOnly = true;
+        internal = true;
         description = "The octal mode of the environment file.";
         type = types.str;
         default = "0400";

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -43,6 +43,12 @@ let
           type = types.nullOr types.lines;
           default = null;
         };
+
+        perms = mkOption {
+          description = "The mode of the environment file.";
+          type = types.str;
+          default = "0400";
+        };
       };
 
       # !!! should this be a submodule?
@@ -74,6 +80,12 @@ let
       file = mkOption {
         description = "A consult-template file which produces EnvironmentFile-compatible output.";
         type = types.path;
+      };
+
+      perms = mkOption {
+        description = "The mode of the environment file.";
+        type = types.str;
+        default = "0400";
       };
     };
   };

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -45,7 +45,7 @@ let
         };
 
         perms = mkOption {
-          description = "The mode of the environment file.";
+          description = "The octal mode of the environment file.";
           type = types.str;
           default = "0400";
         };
@@ -83,7 +83,7 @@ let
       };
 
       perms = mkOption {
-        description = "The mode of the environment file.";
+        description = "The octal mode of the environment file.";
         type = types.str;
         default = "0400";
       };
@@ -119,7 +119,7 @@ let
       };
 
       perms = mkOption {
-        description = "The mode of the secret file.";
+        description = "The octal mode of the secret file.";
         type = types.str;
         default = "0400";
       };

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -47,7 +47,7 @@ let
         perms = mkOption {
           readOnly = true;
           internal = true;
-          description = "The octal mode of the environment file.";
+          description = "The octal mode of the environment file as a string.";
           type = types.str;
           default = "0400";
         };
@@ -87,7 +87,7 @@ let
       perms = mkOption {
         readOnly = true;
         internal = true;
-        description = "The octal mode of the environment file.";
+        description = "The octal mode of the environment file as a string.";
         type = types.str;
         default = "0400";
       };
@@ -123,7 +123,7 @@ let
       };
 
       perms = mkOption {
-        description = "The octal mode of the secret file.";
+        description = "The octal mode of the secret file as a string.";
         type = types.str;
         default = "0400";
       };

--- a/module/helpers.nix
+++ b/module/helpers.nix
@@ -1,5 +1,8 @@
 { lib }:
 {
+  secretFilesRoot = "/tmp/detsys-vault/";
+  environmentFilesRoot = "/run/keys/environment/";
+
   mkScopedMerge = attrs:
     let
       pluckFunc = attr: values: lib.mkMerge
@@ -45,14 +48,16 @@
             (mkCommandAttrset cfg.environment.changeAction) // {
               destination = "/run/keys/environment/EnvFile";
               contents = cfg.environment.template;
+              inherit (cfg.environment) perms;
             }
           ))
         ++ (lib.mapAttrsToList
-          (name: { file }:
+          (name: { file, perms }:
             (
               (mkCommandAttrset cfg.environment.changeAction) // {
                 destination = "/run/keys/environment/${name}.EnvFile";
                 source = file;
+                inherit perms;
               }
             ))
           cfg.environment.templateFiles);

--- a/module/helpers.nix
+++ b/module/helpers.nix
@@ -80,7 +80,7 @@ rec {
               in
               builtins.concatStringsSep ";"
                 ([
-                  "chown ${lib.optionalString (user != null) escapedUser}:${lib.optionalString (group!= null) escapedGroup} ${destination}"
+                  "chown ${lib.optionalString (user != null) escapedUser}:${lib.optionalString (group!= null) escapedGroup} ${lib.escapeShellArg destination}"
                 ] ++ lib.optionals (changeCommand != null) [
                   changeCommand
                 ]);

--- a/module/helpers.nix
+++ b/module/helpers.nix
@@ -1,5 +1,5 @@
 { lib }:
-{
+rec {
   secretFilesRoot = "/tmp/detsys-vault/";
   environmentFilesRoot = "/run/keys/environment/";
 
@@ -46,7 +46,7 @@
         (lib.optional (cfg.environment.template != null)
           (
             (mkCommandAttrset cfg.environment.changeAction) // {
-              destination = "/run/keys/environment/EnvFile";
+              destination = "${environmentFilesRoot}EnvFile";
               contents = cfg.environment.template;
               inherit (cfg.environment) perms;
             }
@@ -55,7 +55,7 @@
           (name: { file, perms }:
             (
               (mkCommandAttrset cfg.environment.changeAction) // {
-                destination = "/run/keys/environment/${name}.EnvFile";
+                destination = "${environmentFilesRoot}${name}.EnvFile";
                 source = file;
                 inherit perms;
               }
@@ -67,7 +67,7 @@
           (
             (mkCommandAttrset (if changeAction != null then changeAction else cfg.secretFiles.defaultChangeAction)) // {
               # This is ~safe because we require PrivateTmp to be true.
-              destination = "/tmp/detsys-vault/${name}";
+              destination = "${secretFilesRoot}${name}";
               inherit perms;
             } //
             (

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -160,7 +160,6 @@ with
       environment = {
         template = "FOO=BAR";
         templateFiles."example-a".file = ./helpers.tests.nix;
-        perms = "0600";
       };
     }
     {
@@ -169,7 +168,7 @@ with
           command = "systemctl try-restart 'example.service'";
           destination = "${helpers.environmentFilesRoot}EnvFile";
           contents = "FOO=BAR";
-          perms = "0600";
+          perms = "0400";
         }
         {
           command = "systemctl try-restart 'example.service'";

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -187,7 +187,7 @@ with
     {
       template = [
         {
-          command = "systemctl try-restart 'example.service'";
+          command = "chown '':'' ${helpers.secretFilesRoot}example;systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example";
           contents = "FOO=BAR";
           perms = "0400";
@@ -202,7 +202,7 @@ with
     {
       template = [
         {
-          command = "systemctl try-restart 'example.service'";
+          command = "chown '':'' ${helpers.secretFilesRoot}example;systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example";
           source = ./helpers.tests.nix;
           perms = "0400";
@@ -220,7 +220,7 @@ with
     {
       template = [
         {
-          command = "systemctl try-reload-or-restart 'example.service'";
+          command = "chown '':'' ${helpers.secretFilesRoot}example;systemctl try-reload-or-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example";
           contents = "FOO=BAR";
           perms = "0400";
@@ -243,13 +243,13 @@ with
     {
       template = [
         {
-          command = "systemctl try-reload-or-restart 'example.service'";
+          command = "chown '':'' ${helpers.secretFilesRoot}example-a;systemctl try-reload-or-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-a";
           contents = "FOO=BAR";
           perms = "0400";
         }
         {
-          command = "systemctl try-restart 'example.service'";
+          command = "chown '':'' ${helpers.secretFilesRoot}example-b;systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-b";
           contents = "FOO=BAR";
           perms = "0600";
@@ -308,13 +308,13 @@ with
       ];
       template = [
         {
-          command = "systemctl try-reload-or-restart 'example.service'";
+          command = "chown '':'' ${helpers.secretFilesRoot}example-a;systemctl try-reload-or-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-a";
           contents = "FOO=BAR";
           perms = "0400";
         }
         {
-          command = "systemctl try-restart 'example.service'";
+          command = "chown '':'' ${helpers.secretFilesRoot}example-b;systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-b";
           contents = "FOO=BAR";
           perms = "0700";

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -69,7 +69,7 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "/run/keys/environment/EnvFile";
+          destination = "${helpers.environmentFilesRoot}EnvFile";
           contents = ''
             {{ with secret "postgresql/creds/hydra" }}
             HYDRA_DBI=dbi:Pg:dbname=hydra;host=the-database-server;username={{ .Data.username }};password={{ .Data.password }};
@@ -87,7 +87,7 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "/run/keys/environment/example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
         }
       ];
@@ -104,7 +104,7 @@ with
       template = [
         {
           command = "systemctl stop 'example.service'";
-          destination = "/run/keys/environment/example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
         }
       ];
@@ -120,7 +120,7 @@ with
     {
       template = [
         {
-          destination = "/run/keys/environment/example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
         }
       ];
@@ -137,12 +137,12 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "/run/keys/environment/example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
         }
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "/run/keys/environment/example-b.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example-b.EnvFile";
           source = ./helpers.tests.nix;
         }
       ];
@@ -159,12 +159,12 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "/run/keys/environment/EnvFile";
+          destination = "${helpers.environmentFilesRoot}EnvFile";
           contents = "FOO=BAR";
         }
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "/run/keys/environment/example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
         }
       ];
@@ -178,7 +178,7 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "/tmp/detsys-vault/example";
+          destination = "${helpers.secretFilesRoot}example";
           contents = "FOO=BAR";
           perms = "0400";
         }
@@ -193,7 +193,7 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "/tmp/detsys-vault/example";
+          destination = "${helpers.secretFilesRoot}example";
           source = ./helpers.tests.nix;
           perms = "0400";
         }
@@ -211,7 +211,7 @@ with
       template = [
         {
           command = "systemctl try-reload-or-restart 'example.service'";
-          destination = "/tmp/detsys-vault/example";
+          destination = "${helpers.secretFilesRoot}example";
           contents = "FOO=BAR";
           perms = "0400";
         }
@@ -234,13 +234,13 @@ with
       template = [
         {
           command = "systemctl try-reload-or-restart 'example.service'";
-          destination = "/tmp/detsys-vault/example-a";
+          destination = "${helpers.secretFilesRoot}example-a";
           contents = "FOO=BAR";
           perms = "0400";
         }
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "/tmp/detsys-vault/example-b";
+          destination = "${helpers.secretFilesRoot}example-b";
           contents = "FOO=BAR";
           perms = "0600";
         }
@@ -299,13 +299,13 @@ with
       template = [
         {
           command = "systemctl try-reload-or-restart 'example.service'";
-          destination = "/tmp/detsys-vault/example-a";
+          destination = "${helpers.secretFilesRoot}example-a";
           contents = "FOO=BAR";
           perms = "0400";
         }
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "/tmp/detsys-vault/example-b";
+          destination = "${helpers.secretFilesRoot}example-b";
           contents = "FOO=BAR";
           perms = "0700";
         }

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -185,7 +185,7 @@ with
     {
       template = [
         {
-          command = "chown : ${helpers.secretFilesRoot}example;systemctl try-restart 'example.service'";
+          command = "chown : '${helpers.secretFilesRoot}example';systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example";
           contents = "FOO=BAR";
           perms = "0400";
@@ -200,7 +200,7 @@ with
     {
       template = [
         {
-          command = "chown : ${helpers.secretFilesRoot}example;systemctl try-restart 'example.service'";
+          command = "chown : '${helpers.secretFilesRoot}example';systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example";
           source = ./helpers.tests.nix;
           perms = "0400";
@@ -218,7 +218,7 @@ with
     {
       template = [
         {
-          command = "chown : ${helpers.secretFilesRoot}example;systemctl try-reload-or-restart 'example.service'";
+          command = "chown : '${helpers.secretFilesRoot}example';systemctl try-reload-or-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example";
           contents = "FOO=BAR";
           perms = "0400";
@@ -241,13 +241,13 @@ with
     {
       template = [
         {
-          command = "chown : ${helpers.secretFilesRoot}example-a;systemctl try-reload-or-restart 'example.service'";
+          command = "chown : '${helpers.secretFilesRoot}example-a';systemctl try-reload-or-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-a";
           contents = "FOO=BAR";
           perms = "0400";
         }
         {
-          command = "chown : ${helpers.secretFilesRoot}example-b;systemctl try-restart 'example.service'";
+          command = "chown : '${helpers.secretFilesRoot}example-b';systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-b";
           contents = "FOO=BAR";
           perms = "0600";
@@ -306,13 +306,13 @@ with
       ];
       template = [
         {
-          command = "chown : ${helpers.secretFilesRoot}example-a;systemctl try-reload-or-restart 'example.service'";
+          command = "chown : '${helpers.secretFilesRoot}example-a';systemctl try-reload-or-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-a";
           contents = "FOO=BAR";
           perms = "0400";
         }
         {
-          command = "chown : ${helpers.secretFilesRoot}example-b;systemctl try-restart 'example.service'";
+          command = "chown : '${helpers.secretFilesRoot}example-b';systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-b";
           contents = "FOO=BAR";
           perms = "0700";

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -123,7 +123,6 @@ with
     {
       template = [
         {
-          command = "";
           destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
           perms = "0400";
@@ -186,7 +185,7 @@ with
     {
       template = [
         {
-          command = "chown '':'' ${helpers.secretFilesRoot}example;systemctl try-restart 'example.service'";
+          command = "chown : ${helpers.secretFilesRoot}example;systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example";
           contents = "FOO=BAR";
           perms = "0400";
@@ -201,7 +200,7 @@ with
     {
       template = [
         {
-          command = "chown '':'' ${helpers.secretFilesRoot}example;systemctl try-restart 'example.service'";
+          command = "chown : ${helpers.secretFilesRoot}example;systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example";
           source = ./helpers.tests.nix;
           perms = "0400";
@@ -219,7 +218,7 @@ with
     {
       template = [
         {
-          command = "chown '':'' ${helpers.secretFilesRoot}example;systemctl try-reload-or-restart 'example.service'";
+          command = "chown : ${helpers.secretFilesRoot}example;systemctl try-reload-or-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example";
           contents = "FOO=BAR";
           perms = "0400";
@@ -242,13 +241,13 @@ with
     {
       template = [
         {
-          command = "chown '':'' ${helpers.secretFilesRoot}example-a;systemctl try-reload-or-restart 'example.service'";
+          command = "chown : ${helpers.secretFilesRoot}example-a;systemctl try-reload-or-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-a";
           contents = "FOO=BAR";
           perms = "0400";
         }
         {
-          command = "chown '':'' ${helpers.secretFilesRoot}example-b;systemctl try-restart 'example.service'";
+          command = "chown : ${helpers.secretFilesRoot}example-b;systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-b";
           contents = "FOO=BAR";
           perms = "0600";
@@ -307,13 +306,13 @@ with
       ];
       template = [
         {
-          command = "chown '':'' ${helpers.secretFilesRoot}example-a;systemctl try-reload-or-restart 'example.service'";
+          command = "chown : ${helpers.secretFilesRoot}example-a;systemctl try-reload-or-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-a";
           contents = "FOO=BAR";
           perms = "0400";
         }
         {
-          command = "chown '':'' ${helpers.secretFilesRoot}example-b;systemctl try-restart 'example.service'";
+          command = "chown : ${helpers.secretFilesRoot}example-b;systemctl try-restart 'example.service'";
           destination = "${helpers.secretFilesRoot}example-b";
           contents = "FOO=BAR";
           perms = "0700";

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -75,6 +75,7 @@ with
             HYDRA_DBI=dbi:Pg:dbname=hydra;host=the-database-server;username={{ .Data.username }};password={{ .Data.password }};
             {{ end }}
           '';
+          perms = "0400";
         }
       ];
     };
@@ -89,6 +90,7 @@ with
           command = "systemctl try-restart 'example.service'";
           destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
+          perms = "0400";
         }
       ];
     };
@@ -106,6 +108,7 @@ with
           command = "systemctl stop 'example.service'";
           destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
+          perms = "0400";
         }
       ];
     };
@@ -122,6 +125,7 @@ with
         {
           destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
+          perms = "0400";
         }
       ];
     };
@@ -139,11 +143,13 @@ with
           command = "systemctl try-restart 'example.service'";
           destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
+          perms = "0400";
         }
         {
           command = "systemctl try-restart 'example.service'";
           destination = "${helpers.environmentFilesRoot}example-b.EnvFile";
           source = ./helpers.tests.nix;
+          perms = "0400";
         }
       ];
     };
@@ -153,6 +159,7 @@ with
       environment = {
         template = "FOO=BAR";
         templateFiles."example-a".file = ./helpers.tests.nix;
+        perms = "0600";
       };
     }
     {
@@ -161,11 +168,13 @@ with
           command = "systemctl try-restart 'example.service'";
           destination = "${helpers.environmentFilesRoot}EnvFile";
           contents = "FOO=BAR";
+          perms = "0600";
         }
         {
           command = "systemctl try-restart 'example.service'";
           destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
+          perms = "0400";
         }
       ];
     };

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -36,7 +36,7 @@ with
 
         filteredAsserts = builtins.map (asrt: asrt.message) (lib.filter (asrt: !asrt.assertion) result.value.assertions);
 
-        actual = (helpers.renderAgentConfig "example" result.value.detsys.systemd.services.example.vaultAgent).agentConfig;
+        actual = (helpers.renderAgentConfig "example" { } result.value.detsys.systemd.services.example.vaultAgent).agentConfig;
       in
       if !result.success
       then
@@ -123,6 +123,7 @@ with
     {
       template = [
         {
+          command = "";
           destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
           source = ./helpers.tests.nix;
           perms = "0400";

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -9,8 +9,8 @@ let
 
   precreateDirectories = serviceName: { user ? null, group ? null }:
     let
-      user' = lib.escapeShellArg (toString user);
-      group' = lib.escapeShellArg (toString group);
+      userEscaped = lib.escapeShellArg (toString user);
+      groupEscaped = lib.escapeShellArg (toString group);
     in
     pkgs.writeShellScript "precreate-dirs-for-${serviceName}" ''
       set -eux
@@ -19,7 +19,7 @@ let
         mkdir -p ${environmentFilesRoot}
 
         mkdir -p ${secretFilesRoot}
-        chown ${lib.optionalString (user != null) user'}:${lib.optionalString (group != null) group'} ${secretFilesRoot}
+        chown ${lib.optionalString (user != null) userEscaped}:${lib.optionalString (group != null) groupEscaped} ${secretFilesRoot}
       )
     '';
 

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -7,6 +7,9 @@ let
 
   precreateTemplateFiles = serviceName: files: { user ? null, group ? null }:
     let
+      user' = lib.escapeShellArg (toString user);
+      group' = lib.escapeShellArg (toString group);
+
       create = lib.concatMapStringsSep "\n"
         (file:
           let
@@ -16,10 +19,10 @@ let
             (
               umask 027
               mkdir -p "$(dirname ${dest})"
-              chown ${lib.optionalString (user != null) (lib.escapeShellArg (toString user))}:${lib.optionalString (group != null) (lib.escapeShellArg (toString group))} "$(dirname ${dest})"
+              chown ${lib.optionalString (user != null) user'}:${lib.optionalString (group != null) group'} "$(dirname ${dest})"
               umask 777
               touch ${dest}
-              chown ${lib.optionalString (user != null) (lib.escapeShellArg (toString user))}:${lib.optionalString (group != null) (lib.escapeShellArg (toString group))} ${dest}
+              chown ${lib.optionalString (user != null) user'}:${lib.optionalString (group != null) group'} ${dest}
             )
           '')
         files;
@@ -75,7 +78,7 @@ let
 
       serviceConfig = {
         PrivateTmp = lib.mkDefault true;
-        ExecStartPre = precreateTemplateFiles serviceName agentConfig.secretFiles
+        ExecStartPre = precreateTemplateFiles serviceName (agentConfig.secretFiles ++ agentConfig.environmentFiles)
           ({ }
             // lib.optionalAttrs (systemdServiceConfig ? User) { user = systemdServiceConfig.User; }
             // lib.optionalAttrs (systemdServiceConfig ? Group) { group = systemdServiceConfig.Group; });

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -80,11 +80,11 @@ let
 
       serviceConfig = {
         PrivateTmp = lib.mkDefault true;
+        ExecStart = "${pkgs.vault}/bin/vault agent -log-level=trace -config ${agentCfgFile}";
         ExecStartPre = precreateTemplateFiles serviceName (agentConfig.secretFiles ++ agentConfig.environmentFiles)
           ({ }
             // lib.optionalAttrs (systemdServiceConfig ? User) { user = systemdServiceConfig.User; }
             // lib.optionalAttrs (systemdServiceConfig ? Group) { group = systemdServiceConfig.Group; });
-        ExecStart = "${pkgs.vault}/bin/vault agent -log-level=trace -config ${agentCfgFile}";
         ExecStartPost = waitFor serviceName
           (map (path: { prefix = environmentFilesRoot; inherit path; }) agentConfig.environmentFiles
             ++ map (path: { prefix = secretFilesRoot; inherit path; }) agentConfig.secretFiles);

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -55,7 +55,6 @@ let
     in
     pkgs.writeShellScript "wait-for-${serviceName}" ''
       set -eux
-      [ ! -d /tmp/detsys-vault ] && ${pkgs.inotify-tools}/bin/inotifywait --quiet --event create --include 'detsys-vault' /tmp
       ${waiter}
       wait
     '';

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -539,9 +539,6 @@ in
               }];
             }];
           }];
-          template_config = [{
-            static_secret_render_interval = "5s";
-          }];
         };
 
         environment.template = ''
@@ -568,7 +565,13 @@ in
         };
       };
 
+      services.nginx.enable = true;
+
       systemd.services.example = {
+        serviceConfig = {
+          User = "nginx";
+          Group = "nginx";
+        };
         script = ''
           cat /tmp/detsys-vault/rand_bytes
           cat /tmp/detsys-vault/rand_bytes-v2
@@ -578,12 +581,11 @@ in
       };
     })
     ''
-      machine.wait_for_job("setup-vault")
-      machine.succeed("sleep 5")
+      machine.wait_for_file("/role_id")
       machine.start_job("example")
+      machine.wait_for_job("detsys-vaultAgent-example")
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /tmp/detsys-vault/rand_bytes"))
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /tmp/detsys-vault/rand_bytes-v2"))
-      machine.wait_for_job("detsys-vaultAgent-example")
       machine.succeed("sleep 1")
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true cat /tmp/detsys-vault/rand_bytes"))
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /tmp/detsys-vault/rand_bytes"))

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -544,6 +544,12 @@ in
           }];
         };
 
+        environment.template = ''
+          {{ with secret "sys/tools/random/9" "format=base64" }}
+          NINE_BYTES={{ .Data.random_bytes }}
+          {{ end }}
+        '';
+
         secretFiles.files."rand_bytes" = {
           perms = "0642";
           template = ''
@@ -566,6 +572,7 @@ in
         script = ''
           cat /tmp/detsys-vault/rand_bytes
           cat /tmp/detsys-vault/rand_bytes-v2
+          echo Have NINE random bytes, from a templated EnvironmentFile! $NINE_BYTES
           sleep infinity
         '';
       };
@@ -582,5 +589,7 @@ in
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /tmp/detsys-vault/rand_bytes"))
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true cat /tmp/detsys-vault/rand_bytes-v2"))
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /tmp/detsys-vault/rand_bytes-v2"))
+      print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true cat /run/keys/environment/EnvFile"))
+      print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /run/keys/environment/EnvFile"))
     '';
 }

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -548,7 +548,7 @@ in
         '';
 
         secretFiles.files."rand_bytes" = {
-          perms = "0642";
+          perms = "642";
           template = ''
             {{ with secret "sys/tools/random/3" "format=base64" }}
             Have THREE random bytes from a templated string! {{ .Data.random_bytes }}
@@ -557,6 +557,7 @@ in
         };
 
         secretFiles.files."rand_bytes-v2" = {
+          perms = "400";
           template = ''
             {{ with secret "sys/tools/random/6" "format=base64" }}
             Have SIX random bytes, also from a templated string! {{ .Data.random_bytes }}


### PR DESCRIPTION
Since we switched to `inotifywait`, envfiles wouldn't work because we'd be waiting for them to appear at `/tmp/detsys-vault/run/keys/environment/EnvFile`. Oops. This fixes that.