### PR TITLE
module: namespace EnvFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,4 @@ systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-serviceName.service -p Private
 
 * the `detsys-vaultAgent-*` unit gets stuck in ExecStartPost if the vault agent dies.
 * there is no way to get the file path of the secret file, so you have to "just know" where it will be
+* "templated" systemd services (e.g. `getty@.service`) are untested, and so we don't know how they will behave

--- a/module/helpers.nix
+++ b/module/helpers.nix
@@ -47,7 +47,7 @@ rec {
         (lib.optional (cfg.environment.template != null)
           (
             {
-              destination = "${environmentFilesRoot}EnvFile";
+              destination = "${environmentFilesRoot}${targetService}/EnvFile";
               contents = cfg.environment.template;
               inherit (cfg.environment) perms;
             } // lib.optionalAttrs (changeCommand != null) {
@@ -58,7 +58,7 @@ rec {
           (name: { file, perms }:
             (
               {
-                destination = "${environmentFilesRoot}${name}.EnvFile";
+                destination = "${environmentFilesRoot}${targetService}/${name}.EnvFile";
                 source = file;
                 inherit perms;
               } // lib.optionalAttrs (changeCommand != null) {

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -69,7 +69,7 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "${helpers.environmentFilesRoot}EnvFile";
+          destination = "${helpers.environmentFilesRoot}example/EnvFile";
           contents = ''
             {{ with secret "postgresql/creds/hydra" }}
             HYDRA_DBI=dbi:Pg:dbname=hydra;host=the-database-server;username={{ .Data.username }};password={{ .Data.password }};
@@ -88,7 +88,7 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example/example-a.EnvFile";
           source = ./helpers.tests.nix;
           perms = "0400";
         }
@@ -106,7 +106,7 @@ with
       template = [
         {
           command = "systemctl stop 'example.service'";
-          destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example/example-a.EnvFile";
           source = ./helpers.tests.nix;
           perms = "0400";
         }
@@ -123,7 +123,7 @@ with
     {
       template = [
         {
-          destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example/example-a.EnvFile";
           source = ./helpers.tests.nix;
           perms = "0400";
         }
@@ -141,13 +141,13 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example/example-a.EnvFile";
           source = ./helpers.tests.nix;
           perms = "0400";
         }
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "${helpers.environmentFilesRoot}example-b.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example/example-b.EnvFile";
           source = ./helpers.tests.nix;
           perms = "0400";
         }
@@ -165,13 +165,13 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "${helpers.environmentFilesRoot}EnvFile";
+          destination = "${helpers.environmentFilesRoot}example/EnvFile";
           contents = "FOO=BAR";
           perms = "0400";
         }
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "${helpers.environmentFilesRoot}example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example/example-a.EnvFile";
           source = ./helpers.tests.nix;
           perms = "0400";
         }

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -84,13 +84,10 @@ in
       };
     })
     ''
-      print(machine.succeed("sleep 5; journalctl -u setup-vault"))
+      machine.wait_for_file("/secret_id")
       machine.start_job("example")
       machine.wait_for_job("detsys-vaultAgent-example")
-      print(machine.succeed("sleep 5; ls /run/keys"))
-      print(machine.succeed("sleep 1; ls /run/keys/environment"))
-      print(machine.succeed("sleep 1; cat /run/keys/environment/EnvFile"))
-      print(machine.succeed("sleep 1; journalctl -u detsys-vaultAgent-example"))
+      print(machine.succeed("cat /run/keys/environment/example/EnvFile"))
     '';
 
   secretFile = mkTest
@@ -367,8 +364,8 @@ in
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /tmp/detsys-vault/rand_bytes"))
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true cat /tmp/detsys-vault/rand_bytes-v2"))
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /tmp/detsys-vault/rand_bytes-v2"))
-      print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true cat /run/keys/environment/EnvFile"))
-      print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /run/keys/environment/EnvFile"))
+      print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true cat /run/keys/environment/example/EnvFile"))
+      print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /run/keys/environment/example/EnvFile"))
     '';
 
   multiEnvironment = mkTest
@@ -422,6 +419,9 @@ in
       machine.wait_for_file("/role_id")
       machine.start_job("example")
       machine.wait_for_job("detsys-vaultAgent-example")
+      print(machine.succeed("cat /run/keys/environment/example/EnvFile"))
+      print(machine.succeed("cat /run/keys/environment/example/a.EnvFile"))
+      print(machine.succeed("cat /run/keys/environment/example/b.EnvFile"))
     '';
 
   delayedVault = mkTest


### PR DESCRIPTION
Otherwise, they'll end up conflicting if you have more than one
agent with any environment-related configuration set.

##### Description

Closes https://github.com/DeterminateSystems/nixos-vault-service/issues/22.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
