### PR TITLE
module: uncomment BindsTo

### DIFF
--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -61,7 +61,8 @@ let
       path = [ pkgs.glibc ];
 
       unitConfig = {
-        # BindsTo = [ fullServiceName ];
+        BindsTo = [ fullServiceName ];
+
         # FIXME: make more easily tunable
         StartLimitIntervalSec = 200;
         StartLimitBurst = 6;

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -492,4 +492,51 @@ in
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true cat /tmp/detsys-vault/rand_bytes-v2"))
       print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true stat /tmp/detsys-vault/rand_bytes-v2"))
     '';
+
+  failedSidecar = mkTest
+    ({ pkgs, ... }: {
+      detsys.systemd.services.example.vaultAgent = {
+        extraConfig = {
+          vault = [{
+            address = "http://127.0.0.1:8200";
+            retry.num_retries = 1;
+          }];
+          auto_auth = [{
+            method = [{
+              config = [{
+                remove_secret_id_file_after_reading = false;
+                role_id_file_path = "/role_id";
+                secret_id_file_path = "/secret_id";
+              }];
+              type = "approle";
+            }];
+          }];
+          template_config = [{
+            static_secret_render_interval = "5s";
+            exit_on_retry_failure = true;
+          }];
+        };
+
+        environment.template = ''
+          {{ with secret "sys/tools/random/3" "format=base64" }}
+          MY_SECRET={{ .Data.non-existent-with-hyphen }}
+          {{ end }}
+        '';
+      };
+      systemd.services.example = {
+        script = ''
+          echo My secret is $MY_SECRET
+          sleep infinity
+        '';
+      };
+    })
+    ''
+      machine.wait_for_file("/secret_id")
+      machine.systemctl("start --no-block example")
+      machine.succeed("sleep 3")
+      machine.succeed("pkill -f wait-for-example")
+      print(machine.fail("systemctl status detsys-vaultAgent-example"))
+      if "dead" not in machine.succeed("systemctl show -p SubState --value example"):
+          raise Exception("unit shouldn't have even started if the sidecar unit failed")
+    '';
 }


### PR DESCRIPTION
##### Description

We don't want the dependent unit to start if the sidecar fails in any
way (in order to limit side-effects).

Prior to this, even if the sidecar failed, the infected unit would still
start up (and likely fail due to missing secrets), which is probably not
ideal.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
