### PR TITLE
vault agent: disable trace logging

### DIFF
--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -70,7 +70,7 @@ let
 
       serviceConfig = {
         PrivateTmp = lib.mkDefault true;
-        ExecStart = "${pkgs.vault}/bin/vault agent -log-level=trace -config ${agentCfgFile}";
+        ExecStart = "${pkgs.vault}/bin/vault agent -config ${agentCfgFile}";
         ExecStartPre = precreateDirectories serviceName
           ({ }
             // lib.optionalAttrs (systemdServiceConfig ? User) { user = systemdServiceConfig.User; }


### PR DESCRIPTION
##### Description

If anything goes wrong the trace logging can swamp a machine and cause it to die.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [ ] Formatted with `nixpkgs-fmt`
- [ ] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
