### PR TITLE
Support default agent configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,33 @@ With a file named `vault-token.ctmpl`:
 }
 ```
 
+### Default Vault Agent configuration
+
+You can set the default `agentConfig` for all units by using the `detsys.defaultAgentConfig` interface.
+
+> **NOTE**: Manually-specified unit `agentConfig`s will override _**all**_ of the the settings specified in the `detsys.defaultAgentConfig` option.
+
+```
+{
+  detsys.defaultAgentConfig = {
+    vault = [{ address = "http://127.0.0.1:8200"; }];
+    auto_auth = [{
+      method = [{
+        config = [{
+          remove_secret_id_file_after_reading = false;
+          role_id_file_path = "/role_id";
+          secret_id_file_path = "/secret_id";
+        }];
+        type = "approle";
+      }];
+    }];
+    template_config = [{
+      static_secret_render_interval = "5s";
+    }];
+  };
+}
+```
+
 ---
 
 # Running tests

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This temporary filessytem will be shared with the target service via the `JoinsN
 
 ```nix
 {
-  detsys.systemd.services."service-name".vaultAgent = {
+  detsys.vaultAgent.systemd.services."service-name" = {
     enable = true;
 
     environment = {
@@ -105,7 +105,7 @@ Getting database credentials for Hydra:
 
 ```nix
 {
-  detsys.systemd.services.hydra-init.vaultAgent = {
+  detsys.vaultAgent.systemd.services.hydra-init = {
     enable = true;
 
     environment.template = ''
@@ -140,7 +140,7 @@ HYDRA_DBI=dbi:Pg:dbname=hydra;host=the-database-server;username={{ .Data.usernam
 
 ```nix
 {
-    detsys.systemd.services.prometheus.vaultAgent = {
+    detsys.vaultAgent.systemd.services.prometheus = {
         enable = true;
 
         environment.templateFiles."dbi".file = ./hydra-dbi-env.ctmpl;
@@ -153,7 +153,7 @@ HYDRA_DBI=dbi:Pg:dbname=hydra;host=the-database-server;username={{ .Data.usernam
 
 ```nix
 {
-  detsys.systemd.services.nginx.vaultAgent = {
+  detsys.vaultAgent.systemd.services.nginx = {
     enable = true;
 
     secretFiles = {
@@ -172,7 +172,7 @@ HYDRA_DBI=dbi:Pg:dbname=hydra;host=the-database-server;username={{ .Data.usernam
 
 ```nix
 {
-    detsys.systemd.services.prometheus.vaultAgent = {
+    detsys.vaultAgent.systemd.services.prometheus = {
         enable = true;
 
         secretFiles = {
@@ -195,7 +195,7 @@ With a file named `vault-token.ctmpl`:
 
 ```nix
 {
-    detsys.systemd.services.prometheus.vaultAgent = {
+    detsys.vaultAgent.systemd.services.prometheus = {
         enable = true;
 
         secretFiles = {
@@ -208,13 +208,13 @@ With a file named `vault-token.ctmpl`:
 
 ### Default Vault Agent configuration
 
-You can set the default `agentConfig` for all units by using the `detsys.defaultAgentConfig` interface.
+You can set the default `agentConfig` for all units by using the `detsys.vaultAgent.defaultAgentConfig` interface.
 
-> **NOTE**: Manually-specified unit `agentConfig`s will override _**all**_ of the the settings specified in the `detsys.defaultAgentConfig` option.
+> **NOTE**: Manually-specified unit `agentConfig`s will override _**all**_ of the the settings specified in the `detsys.vaultAgent.defaultAgentConfig` option.
 
 ```
 {
-  detsys.defaultAgentConfig = {
+  detsys.vaultAgent.defaultAgentConfig = {
     vault = [{ address = "http://127.0.0.1:8200"; }];
     auto_auth = [{
       method = [{

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -15,8 +15,8 @@ let
     options = {
       enable = mkEnableOption "vaultAgent";
 
-      extraConfig = mkOption {
-        description = "Extra assorted config bits. The only place to specify vault and auto_auth config. To be replaced.";
+      agentConfig = mkOption {
+        description = "Vault agent configuration. The only place to specify vault and auto_auth config. To be replaced.";
         type = types.attrsOf types.unspecified;
         default = { };
       };

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -17,8 +17,8 @@ let
 
       agentConfig = mkOption {
         description = "Vault agent configuration. The only place to specify vault and auto_auth config. To be replaced.";
-        type = types.attrsOf types.unspecified;
-        default = { };
+        type = types.nullOr (types.attrsOf types.unspecified);
+        default = null;
       };
 
       # !!! should this be a submodule?
@@ -132,9 +132,17 @@ let
 
 in
 {
-  options.detsys.systemd.services = mkOption {
-    type = types.attrsOf (types.submodule perServiceModule);
-    default = { };
+  options.detsys = {
+    defaultAgentConfig = mkOption {
+      description = "Default Vault agent configuration. Delegates to individual <code>agentConfig</code>s, if set.";
+      type = types.attrsOf types.unspecified;
+      default = { };
+    };
+
+    systemd.services = mkOption {
+      type = types.attrsOf (types.submodule perServiceModule);
+      default = { };
+    };
   };
 
   config = lib.mkMerge [

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -39,7 +39,7 @@ let
         };
 
         template = mkOption {
-          description = "A consult-template snippet which produces EnvironmentFile-compatible output.";
+          description = "A consul-template snippet which produces EnvironmentFile-compatible output.";
           type = types.nullOr types.lines;
           default = null;
         };
@@ -80,7 +80,7 @@ let
   vaultAgentEnvironmentFileModule = { config, ... }: {
     options = {
       file = mkOption {
-        description = "A consult-template file which produces EnvironmentFile-compatible output.";
+        description = "A consul-template file which produces EnvironmentFile-compatible output.";
         type = types.path;
       };
 
@@ -111,13 +111,13 @@ let
       };
 
       templateFile = mkOption {
-        description = "A consult-template file. Conflicts with template.";
+        description = "A consul-template file. Conflicts with template.";
         type = types.nullOr types.path;
         default = null;
       };
 
       template = mkOption {
-        description = "A consult-template snippet. Conflicts with templateFile.";
+        description = "A consul-template snippet. Conflicts with templateFile.";
         type = types.nullOr types.lines;
         default = null;
       };

--- a/module/definition.tests.nix
+++ b/module/definition.tests.nix
@@ -67,7 +67,7 @@ with
         evaluatedCfg
       else if (expect != actual)
       then
-        throw "Unexpected assertions or warnings. Expected: ${builtins.toJSON expect} Got: ${builtins.toJSON actual}"
+        throw "Unexpected assertions or warnings.\nExpected: ${builtins.toJSON expect}\nGot: ${builtins.toJSON actual}"
       else
         "ok";
   }
@@ -75,13 +75,13 @@ with
 suite {
   nothingSet = expectOk {
     systemd.services.nothing-set = { };
-    detsys.systemd.services.nothing-set.vaultAgent = { };
-    detsys.defaultAgentConfig = { };
+    detsys.vaultAgent.systemd.services.nothing-set = { };
+    detsys.vaultAgent.defaultAgentConfig = { };
   };
 
   envTemplate = expectOk {
     systemd.services.env-template = { };
-    detsys.systemd.services.env-template.vaultAgent = {
+    detsys.vaultAgent.systemd.services.env-template = {
       enable = true;
 
       environment.template = ''
@@ -94,7 +94,7 @@ suite {
 
   envTemplateFile = expectOk {
     systemd.services.env-template-file = { };
-    detsys.systemd.services.env-template-file.vaultAgent = {
+    detsys.vaultAgent.systemd.services.env-template-file = {
       enable = true;
       environment.templateFiles."example".file = ./example.ctmpl;
     };
@@ -102,7 +102,7 @@ suite {
 
   envTemplateFileNone = expectEvalError {
     systemd.services.env-template-file = { };
-    detsys.systemd.services.env-template-file.vaultAgent = {
+    detsys.vaultAgent.systemd.services.env-template-file = {
       enable = true;
       environment.templateFiles."example" = { };
     };
@@ -110,7 +110,7 @@ suite {
 
   secretTemplateFile = expectOk {
     systemd.services.secret-template-file = { };
-    detsys.systemd.services.secret-template-file.vaultAgent = {
+    detsys.vaultAgent.systemd.services.secret-template-file = {
       enable = true;
       secretFiles = {
         files."example".templateFile = ./example.ctmpl;
@@ -120,7 +120,7 @@ suite {
 
   secretTemplate = expectOk {
     systemd.services.secret-template = { };
-    detsys.systemd.services.secret-template.vaultAgent = {
+    detsys.vaultAgent.systemd.services.secret-template = {
       enable = true;
       secretFiles = {
         defaultChangeAction = "reload";
@@ -134,12 +134,12 @@ suite {
   secretNoTemplate = expectAssertsWarns
     {
       assertions = [
-        "detsys.systemd.services.secret-template.vaultAgent.secretFiles.example: One of the 'templateFile' and 'template' options must be specified."
+        "detsys.vaultAgent.systemd.services.secret-template.secretFiles.example: One of the 'templateFile' and 'template' options must be specified."
       ];
     }
     {
       systemd.services.secret-template = { };
-      detsys.systemd.services.secret-template.vaultAgent = {
+      detsys.vaultAgent.systemd.services.secret-template = {
         enable = true;
         secretFiles = {
           defaultChangeAction = "reload";
@@ -151,12 +151,12 @@ suite {
   secretMutuallyExclusiveTemplates = expectAssertsWarns
     {
       assertions = [
-        "detsys.systemd.services.secret-template.vaultAgent.secretFiles.example: Both 'templateFile' and 'template' options must be specified, but they are mutually exclusive."
+        "detsys.vaultAgent.systemd.services.secret-template.secretFiles.example: Both 'templateFile' and 'template' options must be specified, but they are mutually exclusive."
       ];
     }
     {
       systemd.services.secret-template = { };
-      detsys.systemd.services.secret-template.vaultAgent = {
+      detsys.vaultAgent.systemd.services.secret-template = {
         enable = true;
         secretFiles = {
           defaultChangeAction = "reload";
@@ -173,7 +173,7 @@ suite {
       {
         assertions = [
           ''
-            detsys.systemd.services.no-private-tmp:
+            detsys.vaultAgent.systemd.services.no-private-tmp:
                 The specified service has PrivateTmp= (systemd.exec(5)) disabled, but it must
                 be enabled to share secrets between the sidecar service and the infected service.
           ''
@@ -181,7 +181,7 @@ suite {
       }
       {
         systemd.services.no-private-tmp.serviceConfig.PrivateTmp = false;
-        detsys.systemd.services.no-private-tmp.vaultAgent = {
+        detsys.vaultAgent.systemd.services.no-private-tmp = {
           enable = true;
           secretFiles = {
             defaultChangeAction = "reload";
@@ -194,8 +194,8 @@ suite {
 
   globalConfig = expectOk {
     systemd.services.global-config = { };
-    detsys.systemd.services.global-config.vaultAgent = { };
-    detsys.defaultAgentConfig = {
+    detsys.vaultAgent.systemd.services.global-config = { };
+    detsys.vaultAgent.defaultAgentConfig = {
       vault = [{
         address = "http://127.0.0.1:8200";
         retry.num_retries = 1;

--- a/module/definition.tests.nix
+++ b/module/definition.tests.nix
@@ -76,6 +76,7 @@ suite {
   nothingSet = expectOk {
     systemd.services.nothing-set = { };
     detsys.systemd.services.nothing-set.vaultAgent = { };
+    detsys.defaultAgentConfig = { };
   };
 
   envTemplate = expectOk {
@@ -190,4 +191,29 @@ suite {
           };
         };
       };
+
+  globalConfig = expectOk {
+    systemd.services.global-config = { };
+    detsys.systemd.services.global-config.vaultAgent = { };
+    detsys.defaultAgentConfig = {
+      vault = [{
+        address = "http://127.0.0.1:8200";
+        retry.num_retries = 1;
+      }];
+      auto_auth = [{
+        method = [{
+          config = [{
+            remove_secret_id_file_after_reading = false;
+            role_id_file_path = "/role_id";
+            secret_id_file_path = "/secret_id";
+          }];
+          type = "approle";
+        }];
+      }];
+      template_config = [{
+        static_secret_render_interval = "5s";
+        exit_on_retry_failure = true;
+      }];
+    };
+  };
 }

--- a/module/helpers.nix
+++ b/module/helpers.nix
@@ -116,7 +116,7 @@ rec {
         (tpl: tpl.destination)
         secretFileTemplates;
 
-      agentConfig = (cfg.extraConfig or { }) // {
+      agentConfig = (cfg.agentConfig or { }) // {
         template = environmentFileTemplates
           ++ secretFileTemplates;
       };

--- a/module/helpers.nix
+++ b/module/helpers.nix
@@ -24,7 +24,7 @@ rec {
     values:
     pluckFuncs attrs values;
 
-  renderAgentConfig = targetService: targetServiceConfig: cfg:
+  renderAgentConfig = targetService: targetServiceConfig: cfg: defaultAgentConfig:
     let
       mkCommand = requestedAction:
         let
@@ -116,9 +116,17 @@ rec {
         (tpl: tpl.destination)
         secretFileTemplates;
 
-      agentConfig = (cfg.agentConfig or { }) // {
-        template = environmentFileTemplates
+      agentConfig =
+        let
+          conf =
+            if cfg.agentConfig != null then
+              cfg.agentConfig
+            else
+              defaultAgentConfig;
+        in
+        conf // {
+          template = environmentFileTemplates
           ++ secretFileTemplates;
-      };
+        };
     };
 }

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -30,13 +30,13 @@ with
       let
         evaluatedCfg = evalCfg {
           systemd.services.example = { };
-          detsys.systemd.services.example.vaultAgent = cfg;
+          detsys.vaultAgent.systemd.services.example = cfg;
         };
         result = safeEval evaluatedCfg;
 
         filteredAsserts = builtins.map (asrt: asrt.message) (lib.filter (asrt: !asrt.assertion) result.value.assertions);
 
-        actual = (helpers.renderAgentConfig "example" { } result.value.detsys.systemd.services.example.vaultAgent globalCfg).agentConfig;
+        actual = (helpers.renderAgentConfig "example" { } result.value.detsys.vaultAgent.systemd.services.example globalCfg).agentConfig;
       in
       if !result.success
       then

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -255,9 +255,9 @@ with
       ];
     };
 
-  extraConfig = expectRenderedConfig
+  agentConfig = expectRenderedConfig
     {
-      extraConfig = {
+      agentConfig = {
         vault = [{ address = "http://127.0.0.1:8200"; }];
         auto_auth = [
           {

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -111,7 +111,7 @@ in
       (lib.mapAttrsToList
         (serviceName: serviceConfig:
           let
-            agentConfig = renderAgentConfig serviceName config.systemd.services.${serviceName} serviceConfig.vaultAgent;
+            agentConfig = renderAgentConfig serviceName config.systemd.services.${serviceName} serviceConfig.vaultAgent config.detsys.defaultAgentConfig;
           in
           {
             systemd.services = {

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -111,7 +111,7 @@ in
       (lib.mapAttrsToList
         (serviceName: serviceConfig:
           let
-            agentConfig = renderAgentConfig serviceName config.systemd.services.${serviceName} serviceConfig.vaultAgent config.detsys.defaultAgentConfig;
+            agentConfig = renderAgentConfig serviceName config.systemd.services.${serviceName} serviceConfig config.detsys.vaultAgent.defaultAgentConfig;
           in
           {
             systemd.services = {
@@ -124,6 +124,6 @@ in
               };
             };
           })
-        config.detsys.systemd.services))
+        config.detsys.vaultAgent.systemd.services))
   ];
 }

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -52,7 +52,7 @@ in
   basicEnvironment = mkTest
     ({ pkgs, ... }: {
       detsys.systemd.services.example.vaultAgent = {
-        extraConfig = {
+        agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
             method = [{
@@ -93,7 +93,7 @@ in
   secretFile = mkTest
     ({ pkgs, ... }: {
       detsys.systemd.services.example.vaultAgent = {
-        extraConfig = {
+        agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
             method = [{
@@ -149,7 +149,7 @@ in
   secretFileSlow = mkTest
     ({ pkgs, ... }: {
       detsys.systemd.services.example.vaultAgent = {
-        extraConfig = {
+        agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
             method = [{
@@ -209,7 +209,7 @@ in
       };
 
       detsys.systemd.services.nginx.vaultAgent = {
-        extraConfig = {
+        agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
             method = [{
@@ -257,7 +257,7 @@ in
       '';
 
       detsys.systemd.services.example.vaultAgent = {
-        extraConfig = {
+        agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
             method = [{
@@ -299,7 +299,7 @@ in
   perms = mkTest
     ({ pkgs, ... }: {
       detsys.systemd.services.example.vaultAgent = {
-        extraConfig = {
+        agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
             method = [{
@@ -371,7 +371,7 @@ in
   multiEnvironment = mkTest
     ({ pkgs, ... }: {
       detsys.systemd.services.example.vaultAgent = {
-        extraConfig = {
+        agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
             method = [{
@@ -430,7 +430,7 @@ in
       systemd.services.setup-vault.wantedBy = lib.mkForce [ ];
 
       detsys.systemd.services.example.vaultAgent = {
-        extraConfig = {
+        agentConfig = {
           vault = [{
             address = "http://127.0.0.1:8200";
           }];
@@ -496,7 +496,7 @@ in
   failedSidecar = mkTest
     ({ pkgs, ... }: {
       detsys.systemd.services.example.vaultAgent = {
-        extraConfig = {
+        agentConfig = {
           vault = [{
             address = "http://127.0.0.1:8200";
             retry.num_retries = 1;

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -51,7 +51,7 @@ in
 {
   basicEnvironment = mkTest
     ({ pkgs, ... }: {
-      detsys.systemd.services.example.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
@@ -92,7 +92,7 @@ in
 
   secretFile = mkTest
     ({ pkgs, ... }: {
-      detsys.systemd.services.example.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
@@ -148,7 +148,7 @@ in
 
   secretFileSlow = mkTest
     ({ pkgs, ... }: {
-      detsys.systemd.services.example.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
@@ -208,7 +208,7 @@ in
         };
       };
 
-      detsys.systemd.services.nginx.vaultAgent = {
+      detsys.vaultAgent.systemd.services.nginx = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
@@ -256,7 +256,7 @@ in
         sleep infinity
       '';
 
-      detsys.systemd.services.example.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
@@ -298,7 +298,7 @@ in
 
   perms = mkTest
     ({ pkgs, ... }: {
-      detsys.systemd.services.example.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
@@ -370,7 +370,7 @@ in
 
   multiEnvironment = mkTest
     ({ pkgs, ... }: {
-      detsys.systemd.services.example.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{
@@ -429,7 +429,7 @@ in
       systemd.services.vault.wantedBy = lib.mkForce [ ];
       systemd.services.setup-vault.wantedBy = lib.mkForce [ ];
 
-      detsys.systemd.services.example.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{
             address = "http://127.0.0.1:8200";
@@ -495,7 +495,7 @@ in
 
   failedSidecar = mkTest
     ({ pkgs, ... }: {
-      detsys.systemd.services.example.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{
             address = "http://127.0.0.1:8200";
@@ -542,7 +542,7 @@ in
 
   defaultConfig = mkTest
     ({ pkgs, ... }: {
-      detsys.defaultAgentConfig = {
+      detsys.vaultAgent.defaultAgentConfig = {
         vault = [{ address = "http://127.0.0.1:8200"; }];
         auto_auth = [{
           method = [{
@@ -559,7 +559,7 @@ in
         }];
       };
 
-      detsys.systemd.services.example.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example = {
         secretFiles.files."rand_bytes".template = ''
           {{ with secret "sys/tools/random/3" "format=base64" }}
           Have THREE random bytes from a templated string! {{ .Data.random_bytes }}
@@ -577,7 +577,7 @@ in
           file;
       };
 
-      detsys.systemd.services.example2.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example2 = {
         secretFiles.files."rand_bytes".template = ''
           {{ with secret "sys/tools/random/3" "format=base64" }}
           Have THREE random bytes from a templated string! {{ .Data.random_bytes }}
@@ -585,7 +585,7 @@ in
         '';
       };
 
-      detsys.systemd.services.example3.vaultAgent = {
+      detsys.vaultAgent.systemd.services.example3 = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
           auto_auth = [{

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -539,4 +539,58 @@ in
       if "dead" not in machine.succeed("systemctl show -p SubState --value example"):
           raise Exception("unit shouldn't have even started if the sidecar unit failed")
     '';
+
+  defaultConfig = mkTest
+    ({ pkgs, ... }: {
+      detsys.defaultAgentConfig = {
+        vault = [{ address = "http://127.0.0.1:8200"; }];
+        auto_auth = [{
+          method = [{
+            config = [{
+              remove_secret_id_file_after_reading = false;
+              role_id_file_path = "/role_id";
+              secret_id_file_path = "/secret_id";
+            }];
+            type = "approle";
+          }];
+        }];
+        template_config = [{
+          static_secret_render_interval = "5s";
+        }];
+      };
+
+      detsys.systemd.services.example.vaultAgent = {
+        secretFiles.files."rand_bytes".template = ''
+          {{ with secret "sys/tools/random/3" "format=base64" }}
+          Have THREE random bytes from a templated string! {{ .Data.random_bytes }}
+          {{ end }}
+        '';
+
+        secretFiles.files."rand_bytes-v2".templateFile =
+          let
+            file = pkgs.writeText "rand_bytes-v2.tpl" ''
+              {{ with secret "sys/tools/random/6" "format=base64" }}
+              Have SIX random bytes, but from a template file! {{ .Data.random_bytes }}
+              {{ end }}
+            '';
+          in
+          file;
+      };
+
+      systemd.services.example = {
+        script = ''
+          cat /tmp/detsys-vault/rand_bytes
+          cat /tmp/detsys-vault/rand_bytes-v2
+          sleep infinity
+        '';
+      };
+    })
+    ''
+      machine.wait_for_file("/secret_id")
+      machine.start_job("example")
+      machine.wait_for_job("detsys-vaultAgent-example")
+      print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true cat /tmp/detsys-vault/rand_bytes"))
+      print(machine.succeed("systemd-run -p JoinsNamespaceOf=detsys-vaultAgent-example.service -p PrivateTmp=true cat /tmp/detsys-vault/rand_bytes-v2"))
+      print(machine.succeed("journalctl -u detsys-vaultAgent-example"))
+    '';
 }


### PR DESCRIPTION
##### Description

Closes https://github.com/DeterminateSystems/nixos-vault-service/issues/14.

Named as `defaultAgentConfig` to make it more obvious that it is the default for all units, unless `agentConfig` is set for that unit. `globalAgentConfig` gives off the impression that everything will be merged together (IMO).

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
