### PR TITLE
WIP: module: kill ExecStartPost if ExecStart failed

### DIFF
--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -41,8 +41,7 @@ let
 
       # wait for ExecStart to exit
       (
-        while [[ (${lib.concatMapStringsSep " || " (file: "! -f ${lib.escapeShellArg file.destination}") files}) ]] \
-           && [ "$(systemctl show detsys-vaultAgent-${serviceName} -p ExecMainExitTimestampMonotonic --value)" -eq 0 ]
+        while [[ (${lib.concatMapStringsSep " || " (file: "! -f ${lib.escapeShellArg file.destination}") files}) ]] && [ "$(systemctl show detsys-vaultAgent-${serviceName} -p ExecMainExitTimestampMonotonic --value)" -eq 0 ]
         do
           sleep 1
         done

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -534,7 +534,6 @@ in
       machine.wait_for_file("/secret_id")
       machine.systemctl("start --no-block example")
       machine.succeed("sleep 3")
-      machine.succeed("pkill -f wait-for-example")
       print(machine.fail("systemctl status detsys-vaultAgent-example"))
       if "dead" not in machine.succeed("systemctl show -p SubState --value example"):
           raise Exception("unit shouldn't have even started if the sidecar unit failed")


### PR DESCRIPTION
The systemd property `ExecMainExitTimestampMonotonic` will be set after
`ExecStart` exits (which means it errored -- otherwise it would continue
to run in the foreground). We also wait for all the secret files to
exist to ensure that the agent ran successfully.

##### Description

Closes #29.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)

---

THIS IS REALLY UGLY AND HACKY :)