### PR TITLE
module: apply mkDefault to restart-related configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ You can set the default `agentConfig` for all units by using the `detsys.vaultAg
 
 > **NOTE**: Manually-specified unit `agentConfig`s will override _**all**_ of the the settings specified in the `detsys.vaultAgent.defaultAgentConfig` option.
 
-```
+```nix
 {
   detsys.vaultAgent.defaultAgentConfig = {
     vault = [{ address = "http://127.0.0.1:8200"; }];
@@ -229,6 +229,35 @@ You can set the default `agentConfig` for all units by using the `detsys.vaultAg
     template_config = [{
       static_secret_render_interval = "5s";
     }];
+  };
+}
+```
+
+## How to Override systemd Service Configuration
+
+By using the NixOS module system, it is possible to override the sidecar's systemd service configuration (e.g. to tune how often the service is allowed to restart):
+
+```nix
+{
+  detsys.vaultAgent.systemd.services.prometheus = {
+    enable = true;
+
+    secretFiles = {
+      defaultChangeAction = "none";
+      files."vault.token".templateFile = ./vault-token.ctmpl;
+    };
+  };
+
+  systemd.services.detsys-vaultAgent-prometheus = {
+    unitConfig = {
+      StartLimitIntervalSec = 300;
+      StartLimitBurst = 10;
+    };
+
+    serviceConfig = {
+      RestartSec = 30;
+      Restart = "always";
+    };
   };
 }
 ```

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -62,14 +62,15 @@ let
 
       unitConfig = {
         BindsTo = [ fullServiceName ];
-
-        # FIXME: make more easily tunable
-        StartLimitIntervalSec = 200;
-        StartLimitBurst = 6;
+        StartLimitIntervalSec = lib.mkDefault 30;
+        StartLimitBurst = lib.mkDefault 6;
       };
 
       serviceConfig = {
         PrivateTmp = lib.mkDefault true;
+        Restart = lib.mkDefault "on-failure";
+        RestartSec = lib.mkDefault 5;
+
         ExecStart = "${pkgs.vault}/bin/vault agent -config ${agentCfgFile}";
         ExecStartPre = precreateDirectories serviceName
           ({ }
@@ -78,10 +79,6 @@ let
         ExecStartPost = waitFor serviceName
           (map (path: { prefix = environmentFilesRoot; inherit (path) destination perms; }) agentConfig.environmentFileTemplates
             ++ map (path: { prefix = secretFilesRoot; inherit (path) destination perms; }) agentConfig.secretFileTemplates);
-
-        # FIXME: make more easily tunable
-        Restart = "on-failure";
-        RestartSec = 5;
       };
 
     };

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -56,12 +56,12 @@ let
 
       wantedBy = [ fullServiceName ];
       before = [ fullServiceName ];
+      bindsTo = [ fullServiceName ];
 
       # Needs getent in PATH
       path = [ pkgs.glibc ];
 
       unitConfig = {
-        BindsTo = [ fullServiceName ];
         StartLimitIntervalSec = lib.mkDefault 30;
         StartLimitBurst = lib.mkDefault 6;
       };


### PR DESCRIPTION
##### Description

One possible approach to https://github.com/DeterminateSystems/nixos-vault-service/issues/24. See https://github.com/DeterminateSystems/nixos-vault-service/issues/24#issuecomment-1089082511.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
