### PR TITLE
README: we use PrivateTmp + JoinsNamespaceOf, not TemporaryFileSystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,7 @@ If the user manually start, restarts, or stops the target service, the agent sid
 
 ### Where do the files go?
 
-> **NOTE:** Currently, we use the systemd `PrivateTmp` directive, which interacts with `JoinsNamespaceOf` in a documented fashion.
-> It is unknown at this time whether `TemporaryFileSystem` exhibits the same functionality (namely, sharing of mountpoints between services) when used in conjunction with `JoinsNamespaceOf`.
-
-We'll create a temporary filesystem in the sidecar using the `TemporaryFileSystem` at `/run/detsys/vaultAgent`.
+We'll create a directory, `/tmp/detsys-vault`, in the sidecar's `/tmp` which will be protected from external access by the `PrivateTmp` directive.
 All generated, secret files will go there.
 This temporary filessytem will be shared with the target service via the `JoinsNamespaceOf` directive.
 


### PR DESCRIPTION
TemporaryFileSystem does not limit external access to the service and
any in its namespace.

##### Description

Clarify that we don't use the `TemporaryFileSystem` directive.

Closes https://github.com/DeterminateSystems/nixos-vault-service/issues/5.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [ ] Formatted with `nixpkgs-fmt`
- [ ] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
