### PR TITLE
module: fix BindsTo ordering

### DIFF
--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -56,7 +56,6 @@ let
 
       wantedBy = [ fullServiceName ];
       before = [ fullServiceName ];
-      bindsTo = [ fullServiceName ];
 
       # Needs getent in PATH
       path = [ pkgs.glibc ];
@@ -89,6 +88,7 @@ let
     in
     {
       after = [ sidecarServiceName ];
+      bindsTo = [ sidecarServiceName ];
       unitConfig = {
         JoinsNamespaceOf = sidecarServiceName;
       };


### PR DESCRIPTION
##### Description

We want the sidecar to cause the main unit to fail, not the main unit
failing to cause the sidecar to restart.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
  * `cargo test --manifest-path ./messenger/Cargo.toml`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
