### PR TITLE
module: simplify and clean up expressions

### DIFF
--- a/module/definition.nix
+++ b/module/definition.nix
@@ -10,7 +10,7 @@ let
     secretFilesRoot
     ;
 
-  vaultAgentModule = { config, ... }: {
+  vaultAgentModule = { ... }: {
     options = {
       enable = mkEnableOption "vaultAgent";
 
@@ -76,7 +76,7 @@ let
     };
   };
 
-  vaultAgentEnvironmentFileModule = { config, ... }: {
+  vaultAgentEnvironmentFileModule = { ... }: {
     options = {
       file = mkOption {
         description = "A consul-template file which produces EnvironmentFile-compatible output.";
@@ -93,7 +93,7 @@ let
     };
   };
 
-  vaultAgentSecretFilesModule = { name, config, ... }: {
+  vaultAgentSecretFilesModule = { name, ... }: {
     options = {
       changeAction = mkOption {
         description = ''
@@ -171,7 +171,7 @@ in
         config.detsys.vaultAgent.systemd.services))
     (mkScopedMerge [ [ "assertions" ] ]
       (lib.mapAttrsToList
-        (serviceName: serviceConfig: {
+        (serviceName: _serviceConfig: {
           assertions = [
             {
               assertion =

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -163,7 +163,7 @@ in
               }
               {
                 assertion = !(secretFileConfig.templateFile != null && secretFileConfig.template != null);
-                message = "detsys.vaultAgent.systemd.services.${serviceName}.secretFiles.${secretFileName}: Both 'templateFile' and 'template' options must be specified, but they are mutually exclusive.";
+                message = "detsys.vaultAgent.systemd.services.${serviceName}.secretFiles.${secretFileName}: Both 'templateFile' and 'template' options are specified, but they are mutually exclusive.";
               }
             ])
             serviceConfig.secretFiles.files);

--- a/module/definition.tests.nix
+++ b/module/definition.tests.nix
@@ -151,7 +151,7 @@ suite {
   secretMutuallyExclusiveTemplates = expectAssertsWarns
     {
       assertions = [
-        "detsys.vaultAgent.systemd.services.secret-template.secretFiles.example: Both 'templateFile' and 'template' options must be specified, but they are mutually exclusive."
+        "detsys.vaultAgent.systemd.services.secret-template.secretFiles.example: Both 'templateFile' and 'template' options are specified, but they are mutually exclusive."
       ];
     }
     {

--- a/module/helpers.nix
+++ b/module/helpers.nix
@@ -80,18 +80,10 @@ rec {
                 ]);
             destination = path;
             inherit perms;
-          } //
-          (
-            if template != null
-            then {
-              contents = template;
-            }
-            else if templateFile != null
-            then {
-              source = templateFile;
-            }
-            else throw ""
-          ))
+          }
+          // lib.optionalAttrs (template != null) { contents = template; }
+          // lib.optionalAttrs (templateFile != null) { source = templateFile; }
+        )
         cfg.secretFiles.files;
     in
     {

--- a/module/helpers.nix
+++ b/module/helpers.nix
@@ -11,10 +11,8 @@ rec {
           (v:
             lib.mkIf
               (lib.hasAttrByPath attr v)
-              (lib.getAttrFromPath attr v)
-          )
-          values
-        );
+              (lib.getAttrFromPath attr v))
+          values);
 
       pluckFuncs = attrs: values:
         lib.mkMerge (builtins.map
@@ -22,8 +20,7 @@ rec {
           attrs);
 
     in
-    values:
-    pluckFuncs attrs values;
+    pluckFuncs attrs;
 
   renderAgentConfig = targetService: targetServiceConfig: cfg: defaultAgentConfig:
     let
@@ -46,30 +43,26 @@ rec {
           changeCommand = mkCommand cfg.environment.changeAction;
         in
         (lib.optional (cfg.environment.template != null)
-          (
-            {
-              destination = "${environmentFilesRoot}${targetService}/EnvFile";
-              contents = cfg.environment.template;
-              inherit (cfg.environment) perms;
-            } // lib.optionalAttrs (changeCommand != null) {
-              command = changeCommand;
-            }
-          ))
+          ({
+            destination = "${environmentFilesRoot}${targetService}/EnvFile";
+            contents = cfg.environment.template;
+            inherit (cfg.environment) perms;
+          } // lib.optionalAttrs (changeCommand != null) {
+            command = changeCommand;
+          }))
         ++ (lib.mapAttrsToList
           (name: { file, perms }:
-            (
-              {
-                destination = "${environmentFilesRoot}${targetService}/${name}.EnvFile";
-                source = file;
-                inherit perms;
-              } // lib.optionalAttrs (changeCommand != null) {
-                command = changeCommand;
-              }
-            ))
+            ({
+              destination = "${environmentFilesRoot}${targetService}/${name}.EnvFile";
+              source = file;
+              inherit perms;
+            } // lib.optionalAttrs (changeCommand != null) {
+              command = changeCommand;
+            }))
           cfg.environment.templateFiles);
 
       secretFileTemplates = lib.mapAttrsToList
-        (name: { changeAction, templateFile, template, perms, path }:
+        (_name: { changeAction, templateFile, template, perms, path }:
           rec {
             command =
               let
@@ -98,8 +91,7 @@ rec {
               source = templateFile;
             }
             else throw ""
-          )
-        )
+          ))
         cfg.secretFiles.files;
     in
     {

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -1,10 +1,8 @@
 { pkgs, lib, config, ... }:
 let
-  helpers = import ./helpers.nix { inherit lib; };
-
   messenger = pkgs.callPackage ../messenger { };
 
-  inherit (helpers)
+  inherit (import ./helpers.nix { inherit lib; })
     mkScopedMerge
     renderAgentConfig
     secretFilesRoot
@@ -56,8 +54,7 @@ let
         Type = "notify";
 
         ExecStartPre = precreateDirectories serviceName
-          ({ }
-            // lib.optionalAttrs (systemdServiceConfig ? User) { user = systemdServiceConfig.User; }
+          (lib.optionalAttrs (systemdServiceConfig ? User) { user = systemdServiceConfig.User; }
             // lib.optionalAttrs (systemdServiceConfig ? Group) { group = systemdServiceConfig.Group; });
 
         ExecStart =


### PR DESCRIPTION
##### Description

Make the Nix expressions slightly more readable.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
  * `cargo test --manifest-path ./messenger/Cargo.toml`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
