### PR TITLE
Fix compatibility with older Nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ let
     url = "https://github.com/DeterminateSystems/nixos-vault-service.git";
     ref = "main";
   };
+
+  vaultModule = import vaultModuleSrc;
 in
 {
-  imports = [ "${vaultModuleSrc}/module/implementation.nix" ];
+  imports = [ vaultModule.nixosModule ];
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ let
   };
 in
 {
-  imports = [ "${vaultModuleSrc}/module/implementation" ];
+  imports = [ "${vaultModuleSrc}/module/implementation.nix" ];
 }
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,16 +29,27 @@
     {
       nixosModule = self.nixosModules.nixos-vault-service;
       nixosModules = {
-        nixos-vault-service = import ./module/implementation.nix;
+        nixos-vault-service = {
+          imports = [
+            ./module/implementation.nix
+          ];
+
+          nixpkgs.overlays = [
+            self.overlays.default
+          ];
+        };
       };
 
       packages = forAllSystems
-        ({ pkgs, ... }: {
+        ({ pkgs, ... }: rec {
           messenger = pkgs.callPackage ./messenger { };
+
+          default = messenger;
         });
 
-      defaultPackage = forAllSystems
-        ({ system, ... }: self.packages.${system}.messenger);
+      overlays.default = final: prev: {
+        messenger = self.packages.${final.stdenv.system}.messenger;
+      };
 
       devShell = forAllSystems
         ({ pkgs, ... }:
@@ -67,7 +78,7 @@
       };
 
       checks.implementation = import ./module/implementation.tests.nix {
-        inherit nixpkgs;
+        inherit nixpkgs self;
         inherit (nixpkgs) lib;
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
         });
 
       overlays.default = final: prev: {
-        messenger = self.packages.${final.stdenv.system}.messenger;
+        detsys-messenger = self.packages.${final.stdenv.system}.messenger;
       };
 
       devShell = forAllSystems

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -1,7 +1,5 @@
 { pkgs, lib, config, ... }:
 let
-  messenger = pkgs.callPackage ../messenger { };
-
   inherit (import ./helpers.nix { inherit lib; })
     mkScopedMerge
     renderAgentConfig
@@ -65,7 +63,7 @@ let
                   ++ map (path: path.destination) agentConfig.secretFileTemplates));
           in
           builtins.concatStringsSep " " [
-            "${messenger}/bin/messenger"
+            "${pkgs.messenger}/bin/messenger"
             "--vault-binary"
             "${pkgs.vault}/bin/vault"
             "--agent-config"

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -63,7 +63,7 @@ let
                   ++ map (path: path.destination) agentConfig.secretFileTemplates));
           in
           builtins.concatStringsSep " " [
-            "${pkgs.messenger}/bin/messenger"
+            "${pkgs.detsys-messenger}/bin/messenger"
             "--vault-binary"
             "${pkgs.vault}/bin/vault"
             "--agent-config"

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -1,4 +1,4 @@
-{ nixpkgs, lib, ... }:
+{ nixpkgs, self, lib, ... }:
 let
   testTools = import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "x86_64-linux"; };
   mkTest = config: testScript:
@@ -6,7 +6,7 @@ let
       inherit testScript;
       machine = { pkgs, ... }: {
         imports = [
-          ./implementation.nix
+          self.nixosModule
           config
         ];
 


### PR DESCRIPTION
##### Description

Prior to this change, the messenger package would not compile when
using older Nixpkgs (e.g. 21.05) because it depends on a feature only
found in newer Nixpkgs (the `cargoLock.lockFile` functionality).

By making an overlay exposing `messenger` and having the module consume
this overlay, as opposed to `pkgs.callPackage`ing the expression, we
will ensure that the proper Nixpkgs (the one we tested against and is
pinned in our flake.lock) is used.

One minor (IMHO) downside is that this does bring another Nixpkgs
instance into the system's closure.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
  * `cargo test --manifest-path ./messenger/Cargo.toml`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
