### PR TITLE
module: require template_config.exit_on_retry_failure to be true

### DIFF
--- a/module/definition.nix
+++ b/module/definition.nix
@@ -16,8 +16,8 @@ let
 
       agentConfig = mkOption {
         description = "Vault agent configuration. The only place to specify vault and auto_auth config. To be replaced.";
-        type = types.nullOr (types.attrsOf types.unspecified);
-        default = null;
+        type = types.attrsOf types.unspecified;
+        default = config.detsys.vaultAgent.defaultAgentConfig;
       };
 
       # !!! should this be a submodule?

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -10,13 +10,15 @@ let
     secretFilesRoot
     ;
 
+  agentConfigType = types.attrsOf types.unspecified;
+
   vaultAgentModule = { ... }: {
     options = {
       enable = mkEnableOption "vaultAgent";
 
       agentConfig = mkOption {
-        description = "Vault agent configuration. The only place to specify vault and auto_auth config. To be replaced.";
-        type = types.attrsOf types.unspecified;
+        description = "Vault agent configuration. The only place to specify vault and auto_auth config.";
+        type = agentConfigType;
         default = config.detsys.vaultAgent.defaultAgentConfig;
       };
 
@@ -141,7 +143,7 @@ in
   options.detsys.vaultAgent = {
     defaultAgentConfig = mkOption {
       description = "Default Vault agent configuration. Defers to individual <code>agentConfig</code>s, if set.";
-      type = types.attrsOf types.unspecified;
+      type = agentConfigType;
       default = { };
     };
 

--- a/module/helpers.nix
+++ b/module/helpers.nix
@@ -22,7 +22,7 @@ rec {
     in
     pluckFuncs attrs;
 
-  renderAgentConfig = targetService: targetServiceConfig: cfg: defaultAgentConfig:
+  renderAgentConfig = targetService: targetServiceConfig: cfg:
     let
       mkCommand = requestedAction:
         let
@@ -100,17 +100,9 @@ rec {
         (tpl: tpl.destination)
         secretFileTemplates;
 
-      agentConfig =
-        let
-          conf =
-            if cfg.agentConfig != null then
-              cfg.agentConfig
-            else
-              defaultAgentConfig;
-        in
-        conf // {
-          template = environmentFileTemplates
+      agentConfig = cfg.agentConfig // {
+        template = environmentFileTemplates
           ++ secretFileTemplates;
-        };
+      };
     };
 }

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -30,13 +30,14 @@ with
       let
         evaluatedCfg = evalCfg {
           systemd.services.example = { };
+          detsys.vaultAgent.defaultAgentConfig = globalCfg;
           detsys.vaultAgent.systemd.services.example = cfg;
         };
         result = safeEval evaluatedCfg;
 
         filteredAsserts = builtins.map (asrt: asrt.message) (lib.filter (asrt: !asrt.assertion) result.value.assertions);
 
-        actual = (helpers.renderAgentConfig "example" { } result.value.detsys.vaultAgent.systemd.services.example globalCfg).agentConfig;
+        actual = (helpers.renderAgentConfig "example" { } result.value.detsys.vaultAgent.systemd.services.example).agentConfig;
       in
       if !result.success
       then

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -118,5 +118,51 @@ in
             };
           })
         config.detsys.vaultAgent.systemd.services))
+    (mkScopedMerge [ [ "assertions" ] ]
+      (lib.mapAttrsToList
+        (serviceName: serviceConfig: {
+          assertions = [
+            {
+              assertion =
+                let
+                  agentConfig =
+                    if serviceConfig.agentConfig != null
+                    then
+                      serviceConfig.agentConfig
+                    else
+                      config.detsys.vaultAgent.defaultAgentConfig;
+                in
+                agentConfig ? template_config
+                && lib.all lib.id
+                  (map
+                    (cfg: cfg ? exit_on_retry_failure && cfg.exit_on_retry_failure)
+                    agentConfig.template_config);
+              message = ''
+                detsys.vaultAgent.systemd.services.${serviceName}:
+                    The agent config does not specify template_config.exit_on_retry_failure or has
+                    it set to false. This is not supported.
+              '';
+            }
+          ];
+        })
+        config.detsys.vaultAgent.systemd.services))
+    {
+      assertions = [
+        {
+          assertion =
+            config.detsys.vaultAgent.defaultAgentConfig == { }
+            || (config.detsys.vaultAgent.defaultAgentConfig ? template_config
+            && lib.all lib.id
+              (map
+                (cfg: cfg ? exit_on_retry_failure && cfg.exit_on_retry_failure)
+                config.detsys.vaultAgent.defaultAgentConfig.template_config));
+          message = ''
+            detsys.vaultAgent.defaultAgentConfig:
+                The default agent config does not specify template_config.exit_on_retry_failure
+                or has it set to false. This is not supported.
+          '';
+        }
+      ];
+    }
   ];
 }

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -104,7 +104,7 @@ in
       (lib.mapAttrsToList
         (serviceName: serviceConfig:
           let
-            agentConfig = renderAgentConfig serviceName config.systemd.services.${serviceName} serviceConfig config.detsys.vaultAgent.defaultAgentConfig;
+            agentConfig = renderAgentConfig serviceName config.systemd.services.${serviceName} serviceConfig;
           in
           {
             systemd.services = {
@@ -124,19 +124,11 @@ in
           assertions = [
             {
               assertion =
-                let
-                  agentConfig =
-                    if serviceConfig.agentConfig != null
-                    then
-                      serviceConfig.agentConfig
-                    else
-                      config.detsys.vaultAgent.defaultAgentConfig;
-                in
-                agentConfig ? template_config
+                serviceConfig.agentConfig ? template_config
                 && lib.all lib.id
                   (map
                     (cfg: cfg ? exit_on_retry_failure && cfg.exit_on_retry_failure)
-                    agentConfig.template_config);
+                    serviceConfig.agentConfig.template_config);
               message = ''
                 detsys.vaultAgent.systemd.services.${serviceName}:
                     The agent config does not specify template_config.exit_on_retry_failure or has

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -66,6 +66,7 @@ in
           }];
           template_config = [{
             static_secret_render_interval = "5s";
+            exit_on_retry_failure = true;
           }];
         };
 
@@ -107,6 +108,7 @@ in
           }];
           template_config = [{
             static_secret_render_interval = "5s";
+            exit_on_retry_failure = true;
           }];
         };
 
@@ -163,6 +165,7 @@ in
           }];
           template_config = [{
             static_secret_render_interval = "5s";
+            exit_on_retry_failure = true;
           }];
         };
 
@@ -223,6 +226,7 @@ in
           }];
           template_config = [{
             static_secret_render_interval = "5s";
+            exit_on_retry_failure = true;
           }];
         };
 
@@ -269,6 +273,9 @@ in
               type = "approle";
             }];
           }];
+          template_config = [{
+            exit_on_retry_failure = true;
+          }];
         };
 
         secretFiles.files."token" = {
@@ -310,6 +317,9 @@ in
                 secret_id_file_path = "/secret_id";
               }];
             }];
+          }];
+          template_config = [{
+            exit_on_retry_failure = true;
           }];
         };
 
@@ -385,6 +395,7 @@ in
           }];
           template_config = [{
             static_secret_render_interval = "5s";
+            exit_on_retry_failure = true;
           }];
         };
 
@@ -446,6 +457,7 @@ in
           }];
           template_config = [{
             static_secret_render_interval = "5s";
+            exit_on_retry_failure = true;
           }];
         };
 
@@ -556,6 +568,7 @@ in
         }];
         template_config = [{
           static_secret_render_interval = "5s";
+          exit_on_retry_failure = true;
         }];
       };
 
@@ -600,6 +613,7 @@ in
           }];
           template_config = [{
             static_secret_render_interval = "1s";
+            exit_on_retry_failure = true;
           }];
         };
 
@@ -664,6 +678,7 @@ in
         }];
         template_config = [{
           static_secret_render_interval = "5s";
+          exit_on_retry_failure = true;
         }];
       };
 


### PR DESCRIPTION
##### Description

Work towards fixing https://github.com/DeterminateSystems/nixos-vault-service/issues/8.

Having this not be true is a footgun -- it will hit the maximum retries and then.... start retrying again. :upside_down_face: 

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
  * `cargo test --manifest-path ./messenger/Cargo.toml`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
  * This is not easily testable because of an implementation bug in messenger: the "backoff until files exist" function is blocking, but the vault agent may exit before it hits the maximum of 15 minutes of retrying. This is fixed in https://github.com/DeterminateSystems/nixos-vault-service/pull/47.
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
