### PR TITLE
module: partially type auto_auth and template_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,17 +141,17 @@ You can set the default `agentConfig` for all units by using the `detsys.vaultAg
 ```nix
 {
   detsys.vaultAgent.defaultAgentConfig = {
-    vault = [{ address = "http://127.0.0.1:8200"; }];
-    auto_auth = [{
+    vault = { address = "http://127.0.0.1:8200"; };
+    auto_auth = {
       method = [{
-        config = [{
+        type = "approle";
+        config = {
           remove_secret_id_file_after_reading = false;
           role_id_file_path = "/role_id";
           secret_id_file_path = "/secret_id";
-        }];
-        type = "approle";
+        };
       }];
-    }];
+    };
     template_config = {
       static_secret_render_interval = "5s";
     };

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ You can set the default `agentConfig` for all units by using the `detsys.vaultAg
         type = "approle";
       }];
     }];
-    template_config = [{
+    template_config = {
       static_secret_render_interval = "5s";
-    }];
+    };
   };
 }
 ```

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -10,7 +10,57 @@ let
     secretFilesRoot
     ;
 
-  agentConfigType = types.attrsOf types.unspecified;
+  autoAuthMethodModule = types.submodule {
+    freeformType = types.attrsOf types.unspecified;
+
+    options = {
+      type = mkOption {
+        type = types.str;
+      };
+
+      config = mkOption {
+        type = types.attrsOf types.unspecified;
+      };
+    };
+  };
+
+  autoAuthModule = types.submodule {
+    freeformType = types.attrsOf types.unspecified;
+
+    options = {
+      method = mkOption {
+        type = types.listOf autoAuthMethodModule;
+        default = [ ];
+      };
+    };
+  };
+
+  templateConfigModule = types.submodule {
+    freeformType = types.attrsOf types.unspecified;
+
+    options = {
+      exit_on_retry_failure = mkOption {
+        type = types.bool;
+        default = true;
+      };
+    };
+  };
+
+  agentConfigType = types.submodule {
+    freeformType = types.attrsOf types.unspecified;
+
+    options = {
+      auto_auth = mkOption {
+        type = autoAuthModule;
+        default = { };
+      };
+
+      template_config = mkOption {
+        type = templateConfigModule;
+        default = { };
+      };
+    };
+  };
 
   vaultAgentModule = { ... }: {
     options = {

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -240,5 +240,34 @@ in
           ];
         })
         config.detsys.vaultAgent.systemd.services))
+    (mkScopedMerge [ [ "assertions" ] ]
+      (lib.mapAttrsToList
+        (serviceName: serviceConfig: {
+          assertions = [
+            {
+              assertion =
+                serviceConfig.agentConfig.template_config.exit_on_retry_failure;
+              message = ''
+                detsys.vaultAgent.systemd.services.${serviceName}:
+                    The agent config does not specify template_config.exit_on_retry_failure or has
+                    it set to false. This is not supported.
+              '';
+            }
+          ];
+        })
+        config.detsys.vaultAgent.systemd.services))
+    {
+      assertions = [
+        {
+          assertion =
+            config.detsys.vaultAgent.defaultAgentConfig.template_config.exit_on_retry_failure;
+          message = ''
+            detsys.vaultAgent.defaultAgentConfig:
+                The default agent config does not specify template_config.exit_on_retry_failure
+                or has it set to false. This is not supported.
+          '';
+        }
+      ];
+    }
   ];
 }

--- a/module/definition.nix
+++ b/module/definition.nix
@@ -249,8 +249,8 @@ in
                 serviceConfig.agentConfig.template_config.exit_on_retry_failure;
               message = ''
                 detsys.vaultAgent.systemd.services.${serviceName}:
-                    The agent config does not specify template_config.exit_on_retry_failure or has
-                    it set to false. This is not supported.
+                    The agent config has template_config.exit_on_retry_failure
+                    set to false. This is not supported.
               '';
             }
           ];
@@ -263,8 +263,8 @@ in
             config.detsys.vaultAgent.defaultAgentConfig.template_config.exit_on_retry_failure;
           message = ''
             detsys.vaultAgent.defaultAgentConfig:
-                The default agent config does not specify template_config.exit_on_retry_failure
-                or has it set to false. This is not supported.
+                The default agent config has template_config.exit_on_retry_failure
+                set to false. This is not supported.
           '';
         }
       ];

--- a/module/definition.tests.nix
+++ b/module/definition.tests.nix
@@ -210,10 +210,10 @@ suite {
           type = "approle";
         }];
       }];
-      template_config = [{
+      template_config = {
         static_secret_render_interval = "5s";
         exit_on_retry_failure = true;
-      }];
+      };
     };
   };
 }

--- a/module/definition.tests.nix
+++ b/module/definition.tests.nix
@@ -216,4 +216,63 @@ suite {
       };
     };
   };
+
+  globalConfigErr =
+    expectAssertsWarns
+      {
+        assertions = [
+          ''
+            detsys.vaultAgent.systemd.services.global-config:
+                The agent config does not specify template_config.exit_on_retry_failure or has
+                it set to false. This is not supported.
+          ''
+          ''
+            detsys.vaultAgent.defaultAgentConfig:
+                The default agent config does not specify template_config.exit_on_retry_failure
+                or has it set to false. This is not supported.
+          ''
+        ];
+      }
+      {
+        systemd.services.global-config = { };
+        detsys.vaultAgent.systemd.services.global-config = { };
+        detsys.vaultAgent.defaultAgentConfig = {
+          vault = [{
+            address = "http://127.0.0.1:8200";
+            retry.num_retries = 1;
+          }];
+          auto_auth = [{
+            method = [{
+              config = [{
+                remove_secret_id_file_after_reading = false;
+                role_id_file_path = "/role_id";
+                secret_id_file_path = "/secret_id";
+              }];
+              type = "approle";
+            }];
+          }];
+          template_config = {
+            static_secret_render_interval = "5s";
+            exit_on_retry_failure = false;
+          };
+        };
+      };
+
+  noExitOnRetry =
+    expectAssertsWarns
+      {
+        assertions = [
+          ''
+            detsys.vaultAgent.systemd.services.test:
+                The agent config does not specify template_config.exit_on_retry_failure or has
+                it set to false. This is not supported.
+          ''
+        ];
+      }
+      {
+        systemd.services.test = { };
+        detsys.vaultAgent.systemd.services.test.agentConfig = {
+          template_config.exit_on_retry_failure = false;
+        };
+      };
 }

--- a/module/definition.tests.nix
+++ b/module/definition.tests.nix
@@ -196,20 +196,20 @@ suite {
     systemd.services.global-config = { };
     detsys.vaultAgent.systemd.services.global-config = { };
     detsys.vaultAgent.defaultAgentConfig = {
-      vault = [{
+      vault = {
         address = "http://127.0.0.1:8200";
         retry.num_retries = 1;
-      }];
-      auto_auth = [{
+      };
+      auto_auth = {
         method = [{
-          config = [{
+          config = {
             remove_secret_id_file_after_reading = false;
             role_id_file_path = "/role_id";
             secret_id_file_path = "/secret_id";
-          }];
+          };
           type = "approle";
         }];
-      }];
+      };
       template_config = {
         static_secret_render_interval = "5s";
         exit_on_retry_failure = true;
@@ -237,20 +237,20 @@ suite {
         systemd.services.global-config = { };
         detsys.vaultAgent.systemd.services.global-config = { };
         detsys.vaultAgent.defaultAgentConfig = {
-          vault = [{
+          vault = {
             address = "http://127.0.0.1:8200";
             retry.num_retries = 1;
-          }];
-          auto_auth = [{
+          };
+          auto_auth = {
             method = [{
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
               type = "approle";
             }];
-          }];
+          };
           template_config = {
             static_secret_render_interval = "5s";
             exit_on_retry_failure = false;

--- a/module/definition.tests.nix
+++ b/module/definition.tests.nix
@@ -223,13 +223,13 @@ suite {
         assertions = [
           ''
             detsys.vaultAgent.systemd.services.global-config:
-                The agent config does not specify template_config.exit_on_retry_failure or has
-                it set to false. This is not supported.
+                The agent config has template_config.exit_on_retry_failure
+                set to false. This is not supported.
           ''
           ''
             detsys.vaultAgent.defaultAgentConfig:
-                The default agent config does not specify template_config.exit_on_retry_failure
-                or has it set to false. This is not supported.
+                The default agent config has template_config.exit_on_retry_failure
+                set to false. This is not supported.
           ''
         ];
       }
@@ -264,8 +264,8 @@ suite {
         assertions = [
           ''
             detsys.vaultAgent.systemd.services.test:
-                The agent config does not specify template_config.exit_on_retry_failure or has
-                it set to false. This is not supported.
+                The agent config has template_config.exit_on_retry_failure
+                set to false. This is not supported.
           ''
         ];
       }

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -56,6 +56,8 @@ with
     { }
     { }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [ ];
     };
 
@@ -69,6 +71,8 @@ with
       '';
     }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "systemctl try-restart 'example.service'";
@@ -89,6 +93,8 @@ with
       environment.templateFiles."example-a".file = ./helpers.tests.nix;
     }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "systemctl try-restart 'example.service'";
@@ -108,6 +114,8 @@ with
       };
     }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "systemctl stop 'example.service'";
@@ -127,6 +135,8 @@ with
       };
     }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           destination = "${helpers.environmentFilesRoot}example/example-a.EnvFile";
@@ -145,6 +155,8 @@ with
       };
     }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "systemctl try-restart 'example.service'";
@@ -170,6 +182,8 @@ with
       };
     }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "systemctl try-restart 'example.service'";
@@ -192,6 +206,8 @@ with
       secretFiles.files."example".template = "FOO=BAR";
     }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "chown : '${helpers.secretFilesRoot}example';systemctl try-restart 'example.service'";
@@ -208,6 +224,8 @@ with
       secretFiles.files."example".templateFile = ./helpers.tests.nix;
     }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "chown : '${helpers.secretFilesRoot}example';systemctl try-restart 'example.service'";
@@ -227,6 +245,8 @@ with
       };
     }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "chown : '${helpers.secretFilesRoot}example';systemctl try-reload-or-restart 'example.service'";
@@ -251,6 +271,8 @@ with
       };
     }
     {
+      auto_auth = [ ];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "chown : '${helpers.secretFilesRoot}example-a';systemctl try-reload-or-restart 'example.service'";
@@ -272,22 +294,16 @@ with
     {
       agentConfig = {
         vault = [{ address = "http://127.0.0.1:8200"; }];
-        auto_auth = [
-          {
-            method = [
-              {
-                config = [
-                  {
-                    remove_secret_id_file_after_reading = false;
-                    role_id_file_path = "role_id";
-                    secret_id_file_path = "secret_id";
-                  }
-                ];
-                type = "approle";
-              }
-            ];
-          }
-        ];
+        auto_auth = [{
+          method = [{
+            config = [{
+              remove_secret_id_file_after_reading = false;
+              role_id_file_path = "role_id";
+              secret_id_file_path = "secret_id";
+            }];
+            type = "approle";
+          }];
+        }];
       };
       secretFiles = {
         defaultChangeAction = "reload";
@@ -301,22 +317,17 @@ with
     }
     {
       vault = [{ address = "http://127.0.0.1:8200"; }];
-      auto_auth = [
-        {
-          method = [
-            {
-              config = [
-                {
-                  remove_secret_id_file_after_reading = false;
-                  role_id_file_path = "role_id";
-                  secret_id_file_path = "secret_id";
-                }
-              ];
-              type = "approle";
-            }
-          ];
-        }
-      ];
+      auto_auth = [{
+        method = [{
+          config = [{
+            remove_secret_id_file_after_reading = false;
+            role_id_file_path = "role_id";
+            secret_id_file_path = "secret_id";
+          }];
+          type = "approle";
+        }];
+      }];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "chown : '${helpers.secretFilesRoot}example-a';systemctl try-reload-or-restart 'example.service'";
@@ -370,6 +381,7 @@ with
           type = "approle";
         }];
       }];
+      template_config.exit_on_retry_failure = true;
       template = [
         {
           command = "chown : '${helpers.secretFilesRoot}example-a';systemctl try-reload-or-restart 'example.service'";

--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -56,7 +56,7 @@ with
     { }
     { }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [ ];
     };
@@ -71,7 +71,7 @@ with
       '';
     }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -93,7 +93,7 @@ with
       environment.templateFiles."example-a".file = ./helpers.tests.nix;
     }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -114,7 +114,7 @@ with
       };
     }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -135,7 +135,7 @@ with
       };
     }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -155,7 +155,7 @@ with
       };
     }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -182,7 +182,7 @@ with
       };
     }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -206,7 +206,7 @@ with
       secretFiles.files."example".template = "FOO=BAR";
     }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -224,7 +224,7 @@ with
       secretFiles.files."example".templateFile = ./helpers.tests.nix;
     }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -245,7 +245,7 @@ with
       };
     }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -271,7 +271,7 @@ with
       };
     }
     {
-      auto_auth = [ ];
+      auto_auth.method = [ ];
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -293,17 +293,17 @@ with
     { }
     {
       agentConfig = {
-        vault = [{ address = "http://127.0.0.1:8200"; }];
-        auto_auth = [{
+        vault = { address = "http://127.0.0.1:8200"; };
+        auto_auth = {
           method = [{
-            config = [{
+            config = {
               remove_secret_id_file_after_reading = false;
               role_id_file_path = "role_id";
               secret_id_file_path = "secret_id";
-            }];
+            };
             type = "approle";
           }];
-        }];
+        };
       };
       secretFiles = {
         defaultChangeAction = "reload";
@@ -316,17 +316,17 @@ with
       };
     }
     {
-      vault = [{ address = "http://127.0.0.1:8200"; }];
-      auto_auth = [{
+      vault = { address = "http://127.0.0.1:8200"; };
+      auto_auth = {
         method = [{
-          config = [{
+          config = {
             remove_secret_id_file_after_reading = false;
             role_id_file_path = "role_id";
             secret_id_file_path = "secret_id";
-          }];
+          };
           type = "approle";
         }];
-      }];
+      };
       template_config.exit_on_retry_failure = true;
       template = [
         {
@@ -346,17 +346,17 @@ with
 
   defaultAgentConfig = expectRenderedConfig
     {
-      vault = [{ address = "http://127.0.0.1:8200"; }];
-      auto_auth = [{
+      vault = { address = "http://127.0.0.1:8200"; };
+      auto_auth = {
         method = [{
-          config = [{
+          config = {
             remove_secret_id_file_after_reading = false;
             role_id_file_path = "role_id";
             secret_id_file_path = "secret_id";
-          }];
+          };
           type = "approle";
         }];
-      }];
+      };
     }
     {
       secretFiles = {
@@ -370,17 +370,17 @@ with
       };
     }
     {
-      vault = [{ address = "http://127.0.0.1:8200"; }];
-      auto_auth = [{
+      vault = { address = "http://127.0.0.1:8200"; };
+      auto_auth = {
         method = [{
-          config = [{
+          config = {
             remove_secret_id_file_after_reading = false;
             role_id_file_path = "role_id";
             secret_id_file_path = "secret_id";
-          }];
+          };
           type = "approle";
         }];
-      }];
+      };
       template_config.exit_on_retry_failure = true;
       template = [
         {

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -116,34 +116,5 @@ in
             };
           })
         config.detsys.vaultAgent.systemd.services))
-    (mkScopedMerge [ [ "assertions" ] ]
-      (lib.mapAttrsToList
-        (serviceName: serviceConfig: {
-          assertions = [
-            {
-              assertion =
-                serviceConfig.agentConfig.template_config.exit_on_retry_failure;
-              message = ''
-                detsys.vaultAgent.systemd.services.${serviceName}:
-                    The agent config does not specify template_config.exit_on_retry_failure or has
-                    it set to false. This is not supported.
-              '';
-            }
-          ];
-        })
-        config.detsys.vaultAgent.systemd.services))
-    {
-      assertions = [
-        {
-          assertion =
-            config.detsys.vaultAgent.defaultAgentConfig.template_config.exit_on_retry_failure;
-          message = ''
-            detsys.vaultAgent.defaultAgentConfig:
-                The default agent config does not specify template_config.exit_on_retry_failure
-                or has it set to false. This is not supported.
-          '';
-        }
-      ];
-    }
   ];
 }

--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -122,11 +122,7 @@ in
           assertions = [
             {
               assertion =
-                serviceConfig.agentConfig ? template_config
-                && lib.all lib.id
-                  (map
-                    (cfg: cfg ? exit_on_retry_failure && cfg.exit_on_retry_failure)
-                    serviceConfig.agentConfig.template_config);
+                serviceConfig.agentConfig.template_config.exit_on_retry_failure;
               message = ''
                 detsys.vaultAgent.systemd.services.${serviceName}:
                     The agent config does not specify template_config.exit_on_retry_failure or has
@@ -140,12 +136,7 @@ in
       assertions = [
         {
           assertion =
-            config.detsys.vaultAgent.defaultAgentConfig == { }
-            || (config.detsys.vaultAgent.defaultAgentConfig ? template_config
-            && lib.all lib.id
-              (map
-                (cfg: cfg ? exit_on_retry_failure && cfg.exit_on_retry_failure)
-                config.detsys.vaultAgent.defaultAgentConfig.template_config));
+            config.detsys.vaultAgent.defaultAgentConfig.template_config.exit_on_retry_failure;
           message = ''
             detsys.vaultAgent.defaultAgentConfig:
                 The default agent config does not specify template_config.exit_on_retry_failure

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -53,7 +53,7 @@ in
     ({ pkgs, ... }: {
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
-          vault = [{ address = "http://127.0.0.1:8200"; }];
+          vault = { address = "http://127.0.0.1:8200"; };
           auto_auth = {
             method = [{
               config = {
@@ -94,7 +94,7 @@ in
     ({ pkgs, ... }: {
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
-          vault = [{ address = "http://127.0.0.1:8200"; }];
+          vault = { address = "http://127.0.0.1:8200"; };
           auto_auth = {
             method = [{
               config = {
@@ -150,7 +150,7 @@ in
     ({ pkgs, ... }: {
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
-          vault = [{ address = "http://127.0.0.1:8200"; }];
+          vault = { address = "http://127.0.0.1:8200"; };
           auto_auth = {
             method = [{
               config = {
@@ -210,7 +210,7 @@ in
 
       detsys.vaultAgent.systemd.services.nginx = {
         agentConfig = {
-          vault = [{ address = "http://127.0.0.1:8200"; }];
+          vault = { address = "http://127.0.0.1:8200"; };
           auto_auth = {
             method = [{
               config = {
@@ -258,7 +258,7 @@ in
 
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
-          vault = [{ address = "http://127.0.0.1:8200"; }];
+          vault = { address = "http://127.0.0.1:8200"; };
           auto_auth = {
             method = [{
               config = {
@@ -300,7 +300,7 @@ in
     ({ pkgs, ... }: {
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
-          vault = [{ address = "http://127.0.0.1:8200"; }];
+          vault = { address = "http://127.0.0.1:8200"; };
           auto_auth = {
             method = [{
               type = "approle";
@@ -372,7 +372,7 @@ in
     ({ pkgs, ... }: {
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
-          vault = [{ address = "http://127.0.0.1:8200"; }];
+          vault = { address = "http://127.0.0.1:8200"; };
           auto_auth = {
             method = [{
               config = {
@@ -431,9 +431,9 @@ in
 
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
-          vault = [{
+          vault = {
             address = "http://127.0.0.1:8200";
-          }];
+          };
           auto_auth = {
             method = [{
               type = "approle";
@@ -497,10 +497,10 @@ in
     ({ pkgs, ... }: {
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
-          vault = [{
+          vault = {
             address = "http://127.0.0.1:8200";
             retry.num_retries = 1;
-          }];
+          };
           auto_auth = {
             method = [{
               config = {
@@ -541,7 +541,7 @@ in
   defaultConfig = mkTest
     ({ pkgs, ... }: {
       detsys.vaultAgent.defaultAgentConfig = {
-        vault = [{ address = "http://127.0.0.1:8200"; }];
+        vault = { address = "http://127.0.0.1:8200"; };
         auto_auth = {
           method = [{
             config = {
@@ -585,7 +585,7 @@ in
 
       detsys.vaultAgent.systemd.services.example3 = {
         agentConfig = {
-          vault = [{ address = "http://127.0.0.1:8200"; }];
+          vault = { address = "http://127.0.0.1:8200"; };
           auto_auth = {
             method = [{
               config = {
@@ -649,7 +649,7 @@ in
   pathToSecret = mkTest
     ({ config, pkgs, ... }: {
       detsys.vaultAgent.defaultAgentConfig = {
-        vault = [{ address = "http://127.0.0.1:8200"; }];
+        vault = { address = "http://127.0.0.1:8200"; };
         auto_auth = {
           method = [{
             config = {
@@ -708,10 +708,10 @@ in
     ({ pkgs, ... }: {
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
-          vault = [{
+          vault = {
             address = "http://127.0.0.1:8200";
             retry.num_retries = 3;
-          }];
+          };
           auto_auth = {
             method = [{
               config = {

--- a/module/implementation.tests.nix
+++ b/module/implementation.tests.nix
@@ -54,20 +54,19 @@ in
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
               type = "approle";
             }];
-          }];
-          template_config = [{
+          };
+          template_config = {
             static_secret_render_interval = "5s";
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         environment.template = ''
@@ -96,20 +95,19 @@ in
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
               type = "approle";
             }];
-          }];
-          template_config = [{
+          };
+          template_config = {
             static_secret_render_interval = "5s";
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         secretFiles.files."rand_bytes".template = ''
@@ -153,20 +151,19 @@ in
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
               type = "approle";
             }];
-          }];
-          template_config = [{
+          };
+          template_config = {
             static_secret_render_interval = "5s";
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         secretFiles.files."slow" = {
@@ -214,20 +211,19 @@ in
       detsys.vaultAgent.systemd.services.nginx = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
               type = "approle";
             }];
-          }];
-          template_config = [{
+          };
+          template_config = {
             static_secret_render_interval = "5s";
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         secretFiles.files."prometheus-basic-auth" = {
@@ -263,19 +259,16 @@ in
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
               type = "approle";
             }];
-          }];
-          template_config = [{
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         secretFiles.files."token" = {
@@ -308,19 +301,16 @@ in
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
               type = "approle";
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
             }];
-          }];
-          template_config = [{
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         environment.template = ''
@@ -383,20 +373,19 @@ in
       detsys.vaultAgent.systemd.services.example = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
               type = "approle";
             }];
-          }];
-          template_config = [{
+          };
+          template_config = {
             static_secret_render_interval = "5s";
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         environment.template = ''
@@ -445,20 +434,19 @@ in
           vault = [{
             address = "http://127.0.0.1:8200";
           }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
               type = "approle";
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
             }];
-          }];
-          template_config = [{
+          };
+          template_config = {
             static_secret_render_interval = "5s";
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         secretFiles.files."rand_bytes" = {
@@ -513,20 +501,19 @@ in
             address = "http://127.0.0.1:8200";
             retry.num_retries = 1;
           }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
               type = "approle";
             }];
-          }];
-          template_config = [{
+          };
+          template_config = {
             static_secret_render_interval = "5s";
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         environment.template = ''
@@ -555,20 +542,19 @@ in
     ({ pkgs, ... }: {
       detsys.vaultAgent.defaultAgentConfig = {
         vault = [{ address = "http://127.0.0.1:8200"; }];
-        auto_auth = [{
+        auto_auth = {
           method = [{
-            config = [{
+            config = {
               remove_secret_id_file_after_reading = false;
               role_id_file_path = "/role_id";
               secret_id_file_path = "/secret_id";
-            }];
+            };
             type = "approle";
           }];
-        }];
-        template_config = [{
+        };
+        template_config = {
           static_secret_render_interval = "5s";
-          exit_on_retry_failure = true;
-        }];
+        };
       };
 
       detsys.vaultAgent.systemd.services.example = {
@@ -600,20 +586,19 @@ in
       detsys.vaultAgent.systemd.services.example3 = {
         agentConfig = {
           vault = [{ address = "http://127.0.0.1:8200"; }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
               type = "approle";
             }];
-          }];
-          template_config = [{
+          };
+          template_config = {
             static_secret_render_interval = "1s";
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         secretFiles.files."rand_bytes".template = ''
@@ -665,20 +650,19 @@ in
     ({ config, pkgs, ... }: {
       detsys.vaultAgent.defaultAgentConfig = {
         vault = [{ address = "http://127.0.0.1:8200"; }];
-        auto_auth = [{
+        auto_auth = {
           method = [{
-            config = [{
+            config = {
               remove_secret_id_file_after_reading = false;
               role_id_file_path = "/role_id";
               secret_id_file_path = "/secret_id";
-            }];
+            };
             type = "approle";
           }];
-        }];
-        template_config = [{
+        };
+        template_config = {
           static_secret_render_interval = "5s";
-          exit_on_retry_failure = true;
-        }];
+        };
       };
 
       detsys.vaultAgent.systemd.services.example = {
@@ -728,20 +712,19 @@ in
             address = "http://127.0.0.1:8200";
             retry.num_retries = 3;
           }];
-          auto_auth = [{
+          auto_auth = {
             method = [{
-              config = [{
+              config = {
                 remove_secret_id_file_after_reading = false;
                 role_id_file_path = "/role_id";
                 secret_id_file_path = "/secret_id";
-              }];
+              };
               type = "approle";
             }];
-          }];
-          template_config = [{
+          };
+          template_config = {
             static_secret_render_interval = "5s";
-            exit_on_retry_failure = true;
-          }];
+          };
         };
 
         environment.template = ''


### PR DESCRIPTION
##### Description

This allows us to:

1) add good defaults (e.g. `template_config.exit_on_retry_failure` now defaults to true instead of asserting when unset)
2) avoid weird format issues because we output to JSON instead of HCL

The only part of the configuration that _needs_ to be a list-of-attrs is `auto_auth.method` -- everything else seems to be just happy as an attrset.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
  * `cargo test --manifest-path ./messenger/Cargo.toml`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
