### PR TITLE
module: invert Wants= and WantedBy= relationship

### DIFF
--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -34,7 +34,7 @@ let
       requires = [ "network.target" ];
       after = [ "network.target" ];
 
-      wantedBy = [ fullServiceName ];
+      wants = [ fullServiceName ];
       before = [ fullServiceName ];
 
       # Needs getent in PATH


### PR DESCRIPTION
Prior to this change, the service described by the `fullServiceName`
variable would never start up if the sidecar service failed the first
time it started up, but succeeded later (we've seen this happen in AWS
EC2 instances, where Vault is not able to talk to AWS immediately upon
startup for whatever reason).

Now, the full service will be able to start after the sidecar service
eventually succeeds (if ever).

##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
  * `cargo test --manifest-path ./messenger/Cargo.toml`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
