### PR TITLE
module: add StopPropagatedFrom= to sidecar unit config

### DIFF
--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -43,6 +43,7 @@ let
       unitConfig = {
         StartLimitIntervalSec = lib.mkDefault 30;
         StartLimitBurst = lib.mkDefault 6;
+        StopPropagatedFrom = [ fullServiceName ];
       };
 
       serviceConfig = {


### PR DESCRIPTION
##### Description

This means stopping the full unit will also stop the sidecar. This also
holds true for units that exit successfully or unsuccessfully.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
  * `cargo test --manifest-path ./messenger/Cargo.toml`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
