### PR TITLE
Fixed Issue with NixOS 23.11

### DIFF
--- a/module/implementation.nix
+++ b/module/implementation.nix
@@ -38,7 +38,7 @@ let
       before = [ fullServiceName ];
 
       # Needs getent in PATH
-      path = [ pkgs.glibc ];
+      path = [ pkgs.glibc pkgs.getent ];
 
       unitConfig = {
         StartLimitIntervalSec = lib.mkDefault 30;


### PR DESCRIPTION
##### Description

I just upgrade to NixOS 23.11 and none of my VaultAgent services were working. After a night or two I finally did enough digging to figure out that `getent` wasn't in the path for VaultAgent. I forked the repo and added the package to the `path` and then tested on my config. All my VaultAgent services are working again. 

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [ ] Formatted with `nixpkgs-fmt`
- [x] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
  * `cargo test --manifest-path ./messenger/Cargo.toml`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
