### PR TITLE
Add a ' to a helper test, to validate escaping is happening

### DIFF
--- a/module/helpers.tests.nix
+++ b/module/helpers.tests.nix
@@ -90,7 +90,7 @@ with
   environmentOneFile = expectRenderedConfig
     { }
     {
-      environment.templateFiles."example-a".file = ./helpers.tests.nix;
+      environment.templateFiles."example'-a".file = ./helpers.tests.nix;
     }
     {
       auto_auth.method = [ ];
@@ -98,7 +98,7 @@ with
       template = [
         {
           command = "systemctl try-restart 'example.service'";
-          destination = "${helpers.environmentFilesRoot}example/example-a.EnvFile";
+          destination = "${helpers.environmentFilesRoot}example/example\'-a.EnvFile";
           source = ./helpers.tests.nix;
           perms = "0400";
         }


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [ ] Formatted with `nixpkgs-fmt`
- [ ] Ran tests with:
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.definition`
  * `nix-instantiate --strict --eval --json ./default.nix -A checks.helpers`
  * `nix-build ./default.nix -A checks.implementation`
  * `cargo test --manifest-path ./messenger/Cargo.toml`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
